### PR TITLE
feat: Referenzzinssatz auto-tracking + Herabsetzungsbegehren (#17)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Strata is a spatial intelligence platform for the Zurich housing market. It models every residential unit as a persistent object in a living registry (from the GWR federal register), enriched with listing data scraped from Flatfox/Homegate, neighborhood intelligence, and map visualization. Not a listing platform — housing infrastructure.
 
-**Current Phase:** Phase 0 — Foundation (Apr–May 2026). GWR pipeline, listing ingestion, and proof-of-concept map are built. Remaining: connect to real PostgreSQL (Supabase), deploy, validate against live data.
+**Current Phase:** Layer 1 (Unit Registry) complete; Layer 2 (auth + watchlists + neighborhood intelligence) in progress. Deployment is currently **DOWN** (Supabase paused, Railway credits out). See **`ROADMAP.md`** for the authoritative, up-to-date status of every layer/feature and the current "Next Actions" — read it each session before planning work.
 
 ## Tech Stack
 
@@ -45,7 +45,11 @@ cd apps/api && uv run ruff format .             # auto-format
 ```bash
 cd apps/api && uv run python -m strata_api.pipeline         # GWR pipeline (download + parse + load)
 cd apps/api && uv run python -m strata_api.pipeline.listing_runner  # listing pipeline
+cd apps/api && uv run python -m strata_api.pipeline.neighborhoods            # quartier intelligence → quartiere/noise GeoJSON
+cd apps/api && uv run python -m strata_api.pipeline.neighborhoods --amenities  # also refetch OSM amenities (Overpass); else reuses cached amenities_raw.json
 ```
+
+Commute/isochrone data uses a self-hosted OpenTripPlanner instance — see `scripts/otp/README.md` (docker-compose + GTFS filtering) to stand it up before running the commute pipeline (`pipeline/commute/`).
 
 ### Database migrations (Alembic)
 ```bash
@@ -73,15 +77,17 @@ cd apps/api && DATABASE_URL=... uv run python -m strata_api.scripts.export_listi
 apps/
   web/              Next.js frontend — map is the primary interface
     src/
-      components/map/   Map.tsx (MapLibre), BuildingPopup, Legend, ListingCards, LayerPanel, QuartierProfile
-      lib/              api.ts (fetch wrappers), map/ (era-colors, noise-colors, quartier-colors)
+      components/map/   Map.tsx (MapLibre), BuildingPopup, Legend, ListingCards, LayerPanel, QuartierProfile,
+                        ComparisonPanel (quartier compare), CommuteLegend, TopBar, WatchButton, WatchlistPanel, BarChart
+      components/auth/  AuthControl.tsx (Supabase Auth UI; hidden when env is placeholder)
+      lib/              api.ts (fetch wrappers), supabase.ts (client), quartier-display.ts, time.ts, map/ (era-colors, noise-colors, quartier-colors)
       app/              page.tsx (single-page map app), layout.tsx
   api/              Python backend
     src/strata_api/
       main.py           FastAPI app entry point, mounts routers + static media
       config.py         pydantic-settings (DATABASE_URL, CORS_ORIGINS, PIPELINE_API_KEY)
       db/               SQLAlchemy models (building, unit, entrance, listing, pipeline_run), session factory, Base
-      routers/          registry, listings, neighborhoods, admin_pipeline
+      routers/          registry, listings, neighborhoods, watchlist, admin_pipeline
       pipeline/
         runner.py           GWR pipeline orchestrator (stadt + kanton sources)
         listing_runner.py   Listing pipeline orchestrator
@@ -91,9 +97,10 @@ apps/
         listing_loader.py   Upsert with change detection + deactivation
         loader.py           GWR upsert (buildings, entrances, units)
         dedup.py            Kanton dedup against Stadt EGIDs
-        neighborhoods/      Quartier data: noise, demographics, aggregator
+        neighborhoods/      Quartier intelligence: noise, demographics, amenities (OSM), construction, vibe profiles, aggregator
+        commute/            Quartier→destination commute times via self-hosted OpenTripPlanner
       scripts/          GeoJSON export scripts
-    alembic/            DB migrations (3 versions: initial, listings, listing media)
+    alembic/            DB migrations (5 versions)
     tests/              Mirrors src structure — pipeline/, routers/, db/, fixtures/
     data/               Downloaded media (images, neighborhoods, recon)
 packages/

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -27,7 +27,7 @@ Update this file when phases shift. Claude Code reads it every session via CLAUD
 | Photos stored | 565+ |
 | Quartiere with profiles | 34 |
 | Noise data points | 1,071,340 |
-| Backend tests | 546 |
+| Backend tests | 583 |
 | Frontend tests | 251 |
 
 ---
@@ -170,12 +170,12 @@ The layer that answers "where should I live?" Four dimensions.
 
 ---
 
-### Layer 7: Legal Intelligence ⚪
+### Layer 7: Legal Intelligence 🟡
 
 | Component | Status | Issue |
 |-----------|--------|-------|
-| Referenzzinssatz auto-tracking | ⚪ Planned | #TBD |
-| Pre-drafted Herabsetzungsbegehren | ⚪ Planned | #TBD |
+| Referenzzinssatz auto-tracking | 🟢 Backend done — history table + `/legal/reference-rate`, per-listing analysis (OR 269a step table) | #17 |
+| Pre-drafted Herabsetzungsbegehren | 🟢 Backend done — `POST /legal/listings/{id}/herabsetzungsbegehren` | #17 |
 | Initial rent challenge analysis (OR Art. 270) | ⚪ Planned | #TBD |
 | Rent increase verification | ⚪ Planned | #TBD |
 | Mängelrüge templates | 💡 Idea | #TBD |

--- a/apps/api/alembic/versions/c3f2a1b09e77_add_reference_rates.py
+++ b/apps/api/alembic/versions/c3f2a1b09e77_add_reference_rates.py
@@ -1,0 +1,67 @@
+"""add_reference_rates
+
+Creates the reference_rates history table (seeded with the documented BWO series)
+and adds listings.base_reference_rate.
+
+Revision ID: c3f2a1b09e77
+Revises: b7e1c9a40d12
+Create Date: 2026-07-01 12:00:00.000000
+
+"""
+import datetime
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = 'c3f2a1b09e77'
+down_revision: str | Sequence[str] | None = 'b7e1c9a40d12'
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+# Documented BWO Referenzzinssatz series (effective_date, rate_percent).
+_SEED: list[tuple[datetime.date, float]] = [
+    (datetime.date(2008, 9, 1), 3.50),
+    (datetime.date(2009, 6, 1), 3.25),
+    (datetime.date(2009, 9, 1), 3.00),
+    (datetime.date(2010, 6, 1), 2.75),
+    (datetime.date(2011, 9, 1), 2.50),
+    (datetime.date(2012, 6, 1), 2.25),
+    (datetime.date(2013, 9, 1), 2.00),
+    (datetime.date(2015, 6, 1), 1.75),
+    (datetime.date(2017, 6, 1), 1.50),
+    (datetime.date(2020, 3, 1), 1.25),
+    (datetime.date(2023, 6, 1), 1.50),
+    (datetime.date(2023, 12, 1), 1.75),
+    (datetime.date(2025, 3, 3), 1.50),
+    (datetime.date(2025, 9, 1), 1.25),
+]
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    reference_rates = op.create_table(
+        'reference_rates',
+        sa.Column('id', sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column('valid_from', sa.Date(), nullable=False),
+        sa.Column('rate_percent', sa.Float(), nullable=False),
+        sa.Column('source', sa.String(length=50), nullable=False),
+        sa.PrimaryKeyConstraint('id'),
+        sa.UniqueConstraint('valid_from', name='uq_reference_rate_valid_from'),
+    )
+    op.bulk_insert(
+        reference_rates,
+        [
+            {'valid_from': valid_from, 'rate_percent': rate, 'source': 'bwo'}
+            for valid_from, rate in _SEED
+        ],
+    )
+    op.add_column('listings', sa.Column('base_reference_rate', sa.Float(), nullable=True))
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_column('listings', 'base_reference_rate')
+    op.drop_table('reference_rates')

--- a/apps/api/src/strata_api/config.py
+++ b/apps/api/src/strata_api/config.py
@@ -9,6 +9,9 @@ class Settings(BaseSettings):
     supabase_url: str = ""
     supabase_service_key: str = ""
     supabase_jwt_secret: str = ""
+    # Fallback current Referenzzinssatz (%) when the reference_rates table is empty.
+    # Verify against bwo.admin.ch; 1.25% as of June 2026.
+    default_reference_rate: float = 1.25
 
     @property
     def cors_origins_list(self) -> list[str]:

--- a/apps/api/src/strata_api/db/models/__init__.py
+++ b/apps/api/src/strata_api/db/models/__init__.py
@@ -9,5 +9,6 @@ from strata_api.db.models.listing import (  # noqa: F401
     ListingUnitMatch,
 )
 from strata_api.db.models.pipeline_run import PipelineRun  # noqa: F401
+from strata_api.db.models.reference_rate import ReferenceRate  # noqa: F401
 from strata_api.db.models.unit import Unit  # noqa: F401
 from strata_api.db.models.watch import Watch  # noqa: F401

--- a/apps/api/src/strata_api/db/models/listing.py
+++ b/apps/api/src/strata_api/db/models/listing.py
@@ -26,6 +26,10 @@ class Listing(TimestampMixin, Base):
     rent_gross: Mapped[int | None] = mapped_column(Integer, nullable=True)
     rent_charges: Mapped[int | None] = mapped_column(Integer, nullable=True)
 
+    # Reference rate the current rent is based on (for Herabsetzungsbegehren analysis).
+    # Usually unknown for scraped listings — inferred from first_seen when absent.
+    base_reference_rate: Mapped[float | None] = mapped_column(Float, nullable=True)
+
     # Unit characteristics
     rooms: Mapped[float | None] = mapped_column(Float, nullable=True)
     area_m2: Mapped[float | None] = mapped_column(Float, nullable=True)

--- a/apps/api/src/strata_api/db/models/reference_rate.py
+++ b/apps/api/src/strata_api/db/models/reference_rate.py
@@ -1,0 +1,21 @@
+"""SQLAlchemy model for the Referenzzinssatz history."""
+from __future__ import annotations
+
+import datetime
+
+from sqlalchemy import Date, Float, String, UniqueConstraint
+from sqlalchemy.orm import Mapped, mapped_column
+
+from strata_api.db.base import Base
+
+
+class ReferenceRate(Base):
+    """One row per published change of the hypothekarischer Referenzzinssatz."""
+
+    __tablename__ = "reference_rates"
+    __table_args__ = (UniqueConstraint("valid_from", name="uq_reference_rate_valid_from"),)
+
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    valid_from: Mapped[datetime.date] = mapped_column(Date, nullable=False)
+    rate_percent: Mapped[float] = mapped_column(Float, nullable=False)
+    source: Mapped[str] = mapped_column(String(50), nullable=False, default="bwo")

--- a/apps/api/src/strata_api/legal/__init__.py
+++ b/apps/api/src/strata_api/legal/__init__.py
@@ -1,0 +1,1 @@
+"""Legal intelligence domain: Referenzzinssatz tracking + tenancy-law helpers."""

--- a/apps/api/src/strata_api/legal/herabsetzung.py
+++ b/apps/api/src/strata_api/legal/herabsetzung.py
@@ -1,0 +1,109 @@
+"""Herabsetzungsbegehren (rent-reduction request) letter generation.
+
+Produces a formatted German letter a tenant can send to their landlord or
+Verwaltung when the Referenzzinssatz has dropped below the level their rent was
+last based on (OR Art. 270a i.V.m. Art. 269a lit. b OR, VMWG Art. 13).
+
+This is a document template, not legal advice: the rendered letter carries an
+explicit reservation for offset factors (Teuerung, Kostensteigerungen), a
+Schlichtungsbehörde reference, and a "keine Rechtsberatung" disclaimer.
+"""
+from __future__ import annotations
+
+import datetime
+from dataclasses import dataclass
+
+from strata_api.legal.referenzzins import RentAnalysis
+
+_MONTHS_DE = {
+    1: "Januar", 2: "Februar", 3: "März", 4: "April", 5: "Mai", 6: "Juni",
+    7: "Juli", 8: "August", 9: "September", 10: "Oktober", 11: "November", 12: "Dezember",
+}
+
+
+def _format_date_de(d: datetime.date) -> str:
+    return f"{d.day}. {_MONTHS_DE[d.month]} {d.year}"
+
+
+def _format_chf(amount: float) -> str:
+    return f"CHF {amount:,.2f}".replace(",", "'")
+
+
+@dataclass(frozen=True)
+class HerabsetzungContext:
+    tenant_name: str
+    tenant_address: str
+    landlord_name: str
+    landlord_address: str
+    property_address: str
+    analysis: RentAnalysis
+    rent_net: float
+    letter_date: datetime.date
+
+
+_TEMPLATE = """{tenant_name}
+{tenant_address}
+
+
+{landlord_name}
+{landlord_address}
+
+
+{letter_date}
+Einschreiben
+
+
+Herabsetzungsbegehren für die Mietwohnung {property_address}
+
+Sehr geehrte Damen und Herren
+
+Der hypothekarische Referenzzinssatz, auf dem mein aktueller Mietzins basiert, ist
+gesunken. Gestützt auf Art. 270a OR in Verbindung mit Art. 269a lit. b OR und
+Art. 13 VMWG beantrage ich hiermit eine Herabsetzung des Netto-Mietzinses.
+
+- Referenzzinssatz bei letzter Mietzinsfestsetzung: {base_rate}
+- Aktueller Referenzzinssatz: {current_rate}
+- Zulässige Mietzinsherabsetzung: {change_pct}
+- Aktueller Netto-Mietzins: {rent_net_chf}
+- Beantragte Herabsetzung: {monthly_chf} pro Monat
+- Neuer Netto-Mietzins: {new_rent_chf}
+
+Ich ersuche Sie, die Mietzinsherabsetzung auf den nächstmöglichen Kündigungstermin
+umzusetzen und mir die Anpassung schriftlich zu bestätigen.
+
+Der genannte Betrag versteht sich vorbehältlich einer Verrechnung mit
+aufgelaufener Teuerung und allgemeinen Kostensteigerungen.
+
+Sollten Sie diesem Begehren nicht entsprechen, behalte ich mir vor, fristgerecht
+die Schlichtungsbehörde in Mietsachen anzurufen.
+
+Freundliche Grüsse
+
+
+{tenant_name}
+
+
+---
+Hinweis: Dieses Schreiben wurde automatisch als Vorlage erstellt und stellt
+keine Rechtsberatung dar. Prüfen Sie die Angaben anhand Ihres Mietvertrags."""
+
+
+def render(context: HerabsetzungContext) -> str:
+    """Render the Herabsetzungsbegehren letter text from a context."""
+    if not context.tenant_name.strip():
+        raise ValueError("tenant_name is required")
+    a = context.analysis
+    return _TEMPLATE.format(
+        tenant_name=context.tenant_name,
+        tenant_address=context.tenant_address,
+        landlord_name=context.landlord_name,
+        landlord_address=context.landlord_address,
+        property_address=context.property_address,
+        letter_date=_format_date_de(context.letter_date),
+        base_rate=f"{a.base_rate:.2f}%",
+        current_rate=f"{a.current_rate:.2f}%",
+        change_pct=f"{abs(a.change_pct):.2f}%",
+        rent_net_chf=_format_chf(context.rent_net),
+        monthly_chf=_format_chf(abs(a.monthly_chf)),
+        new_rent_chf=_format_chf(abs(a.new_rent_net)),
+    )

--- a/apps/api/src/strata_api/legal/rates.py
+++ b/apps/api/src/strata_api/legal/rates.py
@@ -1,0 +1,52 @@
+"""Referenzzinssatz history and current-value resolution.
+
+The BWO (Bundesamt für Wohnungswesen) publishes the mortgage reference rate
+quarterly, rounded to the nearest 0.25. RATE_HISTORY is the documented series of
+change points; the current value (1.25% — verified against bwo.admin.ch, June
+2026, unchanged since Sept 2025) is the last entry.
+
+At runtime the DB `reference_rates` table is the source of truth (seeded from
+this series via migration). These pure helpers back that seed and the
+"assumed from first_seen" inference for listings without a recorded base rate.
+"""
+from __future__ import annotations
+
+import datetime
+
+# (effective_date, rate_percent) — documented BWO series, ascending by date.
+RATE_HISTORY: tuple[tuple[datetime.date, float], ...] = (
+    (datetime.date(2008, 9, 1), 3.50),
+    (datetime.date(2009, 6, 1), 3.25),
+    (datetime.date(2009, 9, 1), 3.00),
+    (datetime.date(2010, 6, 1), 2.75),
+    (datetime.date(2011, 9, 1), 2.50),
+    (datetime.date(2012, 6, 1), 2.25),
+    (datetime.date(2013, 9, 1), 2.00),
+    (datetime.date(2015, 6, 1), 1.75),
+    (datetime.date(2017, 6, 1), 1.50),
+    (datetime.date(2020, 3, 1), 1.25),
+    (datetime.date(2023, 6, 1), 1.50),
+    (datetime.date(2023, 12, 1), 1.75),
+    (datetime.date(2025, 3, 3), 1.50),
+    (datetime.date(2025, 9, 1), 1.25),
+)
+
+FALLBACK_REFERENCE_RATE: float = 1.25
+
+
+def rate_at(on_date: datetime.date | datetime.datetime, history=RATE_HISTORY) -> float | None:
+    """Return the reference rate effective on ``on_date``, or None if before the series."""
+    if isinstance(on_date, datetime.datetime):
+        on_date = on_date.date()
+    effective: float | None = None
+    for eff_date, rate in history:
+        if eff_date <= on_date:
+            effective = rate
+        else:
+            break
+    return effective
+
+
+def latest_rate(history=RATE_HISTORY) -> float:
+    """Return the most recent rate in the documented series."""
+    return history[-1][1]

--- a/apps/api/src/strata_api/legal/referenzzins.py
+++ b/apps/api/src/strata_api/legal/referenzzins.py
@@ -1,0 +1,81 @@
+"""Referenzzinssatz-based rent-adjustment math.
+
+Encodes the Swiss legal mechanic for rent changes tied to the mortgage
+reference rate (hypothekarischer Referenzzinssatz), per OR Art. 269a lit. b and
+VMWG Art. 13 Abs. 1 lit. c: for reference rates below 5%, each 0.25
+percentage-point step corresponds to a 3% rent change, compounded.
+
+A drop in the reference rate permits a rent *reduction* (Herabsetzungsanspruch);
+a rise permits an *increase*. Offset factors (Teuerung, allgemeine
+Kostensteigerungen) are deliberately out of scope for this first version — the
+generated documents state that reservation explicitly.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+STEP = 0.25          # reference-rate quantum, in percentage points
+STEP_FACTOR = 1.03   # 3% rent change per 0.25-point step
+RATE_MIN = 0.25
+RATE_MAX = 7.00
+
+_QUARTER_TOLERANCE = 1e-9
+
+
+def _validate_rate(rate: float) -> None:
+    if not RATE_MIN <= rate <= RATE_MAX:
+        raise ValueError(f"reference rate {rate} out of range [{RATE_MIN}, {RATE_MAX}]")
+    steps = rate / STEP
+    if abs(steps - round(steps)) > _QUARTER_TOLERANCE:
+        raise ValueError(f"reference rate {rate} is not a multiple of {STEP}")
+
+
+def permitted_change_pct(base_rate: float, current_rate: float) -> float:
+    """Signed permitted rent change in percent (negative = reduction)."""
+    _validate_rate(base_rate)
+    _validate_rate(current_rate)
+    delta_steps = (base_rate - current_rate) / STEP
+    pct = (STEP_FACTOR ** (-delta_steps) - 1) * 100
+    return round(pct, 2)
+
+
+def monthly_reduction_chf(rent_net: float, change_pct: float) -> float:
+    """Absolute monthly CHF impact of a percentage change on the net rent."""
+    if rent_net < 0:
+        raise ValueError("rent_net must be non-negative")
+    return abs(round(rent_net * change_pct / 100, 2))
+
+
+@dataclass(frozen=True)
+class RentAnalysis:
+    """Result of applying a reference-rate change to a specific net rent."""
+
+    base_rate: float
+    current_rate: float
+    change_pct: float        # signed (negative = reduction)
+    monthly_chf: float       # signed (negative = reduction)
+    new_rent_net: float
+    direction: str           # "reduction" | "increase" | "none"
+
+
+def analyze_rent(base_rate: float, current_rate: float, rent_net: float) -> RentAnalysis:
+    """Full structured analysis for a rent basis vs. the current reference rate."""
+    if rent_net < 0:
+        raise ValueError("rent_net must be non-negative")
+    change_pct = permitted_change_pct(base_rate, current_rate)
+    monthly_chf = round(rent_net * change_pct / 100, 2)
+    new_rent_net = round(rent_net + monthly_chf, 2)
+    if change_pct < 0:
+        direction = "reduction"
+    elif change_pct > 0:
+        direction = "increase"
+    else:
+        direction = "none"
+    return RentAnalysis(
+        base_rate=base_rate,
+        current_rate=current_rate,
+        change_pct=change_pct,
+        monthly_chf=monthly_chf,
+        new_rent_net=new_rent_net,
+        direction=direction,
+    )

--- a/apps/api/src/strata_api/main.py
+++ b/apps/api/src/strata_api/main.py
@@ -5,7 +5,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 
 from strata_api.config import settings
-from strata_api.routers import admin_pipeline, listings, neighborhoods, registry, watchlist
+from strata_api.routers import admin_pipeline, listings, neighborhoods, referenzzins, registry, watchlist
 
 app = FastAPI(title="Strata API", version="0.1.0")
 
@@ -22,6 +22,7 @@ app.include_router(listings.router)
 app.include_router(registry.router)
 app.include_router(neighborhoods.router)
 app.include_router(watchlist.router)
+app.include_router(referenzzins.router)
 
 
 # Serve downloaded images/documents at /media/images/{egid}/...

--- a/apps/api/src/strata_api/routers/referenzzins.py
+++ b/apps/api/src/strata_api/routers/referenzzins.py
@@ -1,0 +1,180 @@
+"""Legal intelligence endpoints — Referenzzinssatz rent analysis + Herabsetzungsbegehren.
+
+Public (unauthenticated) for the MVP so exploration is never gated; Pro-gating of
+letter generation can be layered on later. All rent math lives in ``strata_api.legal``;
+this router only resolves the rate basis and serialises responses.
+"""
+from __future__ import annotations
+
+import datetime
+
+from fastapi import APIRouter, HTTPException, Query
+from pydantic import BaseModel, Field
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from strata_api.config import settings
+from strata_api.db.models.listing import Listing
+from strata_api.db.models.reference_rate import ReferenceRate
+from strata_api.db.session import get_engine
+from strata_api.legal import rates
+from strata_api.legal.herabsetzung import HerabsetzungContext, render
+from strata_api.legal.referenzzins import analyze_rent, permitted_change_pct
+
+router = APIRouter(prefix="/legal", tags=["legal"])
+
+
+class LetterRequest(BaseModel):
+    tenant_name: str = Field(min_length=1)
+    tenant_address: str = ""
+    landlord_name: str = ""
+    landlord_address: str = ""
+    property_address: str | None = None
+    base_rate: float | None = None
+    actual_rent: int | None = None
+
+
+def _current_rate(s: Session) -> float:
+    row = s.execute(
+        select(ReferenceRate).order_by(ReferenceRate.valid_from.desc())
+    ).scalars().first()
+    return row.rate_percent if row else settings.default_reference_rate
+
+
+def _resolve_base_rate(listing: Listing, override: float | None) -> tuple[float | None, str]:
+    """Return (base_rate, basis) — basis is override | known | assumed_from_first_seen | unknown."""
+    if override is not None:
+        return override, "override"
+    if listing.base_reference_rate is not None:
+        return listing.base_reference_rate, "known"
+    if listing.first_seen is not None:
+        inferred = rates.rate_at(listing.first_seen)
+        if inferred is not None:
+            return inferred, "assumed_from_first_seen"
+    return None, "unknown"
+
+
+def _validate_override(base_rate: float | None) -> None:
+    if base_rate is None:
+        return
+    try:
+        permitted_change_pct(base_rate, base_rate)  # validates range + quarter-step
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+
+def _analysis_message(base_rate: float, current_rate: float, monthly_chf: float | None, direction: str) -> str:
+    if direction == "reduction" and monthly_chf is not None:
+        return (
+            f"This rent is based on a {base_rate:.2f}% reference rate. The current rate is "
+            f"{current_rate:.2f}%. You may be entitled to a CHF {abs(monthly_chf):.2f}/month reduction."
+        )
+    if direction == "reduction":
+        return (
+            f"The reference rate has dropped from {base_rate:.2f}% to {current_rate:.2f}%, "
+            "but the rent amount is unknown so the CHF impact cannot be computed."
+        )
+    if direction == "increase":
+        return f"The reference rate has risen from {base_rate:.2f}% to {current_rate:.2f}%; no reduction applies."
+    return "The current reference rate matches this rent's basis; no adjustment applies."
+
+
+def _build_analysis_response(listing: Listing, current_rate: float, override: float | None) -> dict:
+    base_rate, basis = _resolve_base_rate(listing, override)
+    resp: dict = {
+        "listing_id": listing.id,
+        "basis": basis,
+        "base_rate": base_rate,
+        "current_rate": current_rate,
+        "rent_net": listing.rent_net,
+        "change_pct": None,
+        "monthly_chf": None,
+        "new_rent_net": None,
+        "direction": None,
+        "message": "No reference-rate basis known for this listing; provide base_rate to analyse.",
+    }
+    if base_rate is None:
+        return resp
+
+    change_pct = permitted_change_pct(base_rate, current_rate)
+    direction = "reduction" if change_pct < 0 else "increase" if change_pct > 0 else "none"
+    resp["change_pct"] = change_pct
+    resp["direction"] = direction
+    if listing.rent_net is not None:
+        analysis = analyze_rent(base_rate, current_rate, listing.rent_net)
+        resp["monthly_chf"] = analysis.monthly_chf
+        resp["new_rent_net"] = analysis.new_rent_net
+    resp["message"] = _analysis_message(base_rate, current_rate, resp["monthly_chf"], direction)
+    return resp
+
+
+@router.get("/reference-rate")
+def get_reference_rate() -> dict:
+    """Return the current Referenzzinssatz and its published history."""
+    with Session(get_engine()) as s:
+        rows = s.execute(
+            select(ReferenceRate).order_by(ReferenceRate.valid_from.desc())
+        ).scalars().all()
+    if rows:
+        current = {"rate_percent": rows[0].rate_percent, "valid_from": rows[0].valid_from.isoformat()}
+    else:
+        current = {"rate_percent": settings.default_reference_rate, "valid_from": None}
+    return {
+        "current": current,
+        "history": [
+            {"rate_percent": r.rate_percent, "valid_from": r.valid_from.isoformat(), "source": r.source}
+            for r in rows
+        ],
+    }
+
+
+@router.get("/listings/{listing_id}/rent-analysis")
+def rent_analysis(listing_id: int, base_rate: float | None = Query(default=None)) -> dict:
+    """Per-listing rent analysis vs. the current reference rate."""
+    _validate_override(base_rate)
+    with Session(get_engine()) as s:
+        listing = s.get(Listing, listing_id)
+        if listing is None:
+            raise HTTPException(status_code=404, detail="listing not found")
+        current_rate = _current_rate(s)
+        return _build_analysis_response(listing, current_rate, base_rate)
+
+
+@router.post("/listings/{listing_id}/herabsetzungsbegehren")
+def generate_letter(listing_id: int, req: LetterRequest) -> dict:
+    """Generate a Herabsetzungsbegehren letter for a listing (409 if no reduction applies)."""
+    _validate_override(req.base_rate)
+    with Session(get_engine()) as s:
+        listing = s.get(Listing, listing_id)
+        if listing is None:
+            raise HTTPException(status_code=404, detail="listing not found")
+        current_rate = _current_rate(s)
+        base_rate, basis = _resolve_base_rate(listing, req.base_rate)
+        if base_rate is None:
+            raise HTTPException(status_code=409, detail="No reference-rate basis known; provide base_rate.")
+        rent_net = req.actual_rent if req.actual_rent is not None else listing.rent_net
+        if rent_net is None:
+            raise HTTPException(status_code=409, detail="Rent amount unknown; provide actual_rent.")
+        analysis = analyze_rent(base_rate, current_rate, rent_net)
+        if analysis.direction != "reduction":
+            raise HTTPException(status_code=409, detail="No rent reduction applies at the current reference rate.")
+        context = HerabsetzungContext(
+            tenant_name=req.tenant_name,
+            tenant_address=req.tenant_address,
+            landlord_name=req.landlord_name,
+            landlord_address=req.landlord_address,
+            property_address=req.property_address or _listing_address(listing),
+            analysis=analysis,
+            rent_net=rent_net,
+            letter_date=datetime.date.today(),
+        )
+        letter = render(context)
+    return {"listing_id": listing_id, "basis": basis, "letter": letter}
+
+
+def _listing_address(listing: Listing) -> str:
+    head = " ".join(p for p in [listing.street, listing.house_number] if p)
+    tail = " ".join(p for p in [str(listing.plz) if listing.plz else None, listing.city] if p)
+    if head and tail:
+        return f"{head}, {tail}"
+    return head or tail or "unbekannte Adresse"

--- a/apps/api/tests/db/test_reference_rate_model.py
+++ b/apps/api/tests/db/test_reference_rate_model.py
@@ -1,0 +1,53 @@
+"""Tests for the ReferenceRate model and the listings.base_reference_rate column."""
+import datetime
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+from sqlalchemy.pool import StaticPool
+
+from strata_api.db import models  # noqa: F401
+from strata_api.db.base import Base
+from strata_api.db.models.listing import Listing
+from strata_api.db.models.reference_rate import ReferenceRate
+
+
+@pytest.fixture
+def engine():
+    eng = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(eng)
+    return eng
+
+
+def test_reference_rate_roundtrips(engine):
+    with Session(engine) as s:
+        s.add(ReferenceRate(valid_from=datetime.date(2025, 9, 1), rate_percent=1.25, source="bwo"))
+        s.commit()
+        row = s.query(ReferenceRate).one()
+        assert row.rate_percent == 1.25
+        assert row.source == "bwo"
+
+
+def test_reference_rate_valid_from_is_unique(engine):
+    with Session(engine) as s:
+        s.add(ReferenceRate(valid_from=datetime.date(2025, 9, 1), rate_percent=1.25))
+        s.add(ReferenceRate(valid_from=datetime.date(2025, 9, 1), rate_percent=1.50))
+        with pytest.raises(IntegrityError):
+            s.commit()
+
+
+def test_listing_base_reference_rate_defaults_none_and_roundtrips(engine):
+    now = datetime.datetime.utcnow()
+    with Session(engine) as s:
+        s.add(Listing(source="flatfox", source_id="A", first_seen=now, last_seen=now))
+        s.add(Listing(source="flatfox", source_id="B", base_reference_rate=1.75, first_seen=now, last_seen=now))
+        s.commit()
+        a = s.query(Listing).filter_by(source_id="A").one()
+        b = s.query(Listing).filter_by(source_id="B").one()
+        assert a.base_reference_rate is None
+        assert b.base_reference_rate == 1.75

--- a/apps/api/tests/legal/test_herabsetzung.py
+++ b/apps/api/tests/legal/test_herabsetzung.py
@@ -1,0 +1,65 @@
+"""Unit tests for Herabsetzungsbegehren letter rendering."""
+import datetime
+
+import pytest
+
+from strata_api.legal.herabsetzung import HerabsetzungContext, render
+from strata_api.legal.referenzzins import analyze_rent
+
+
+def _context(**overrides):
+    analysis = analyze_rent(base_rate=1.75, current_rate=1.25, rent_net=2000)
+    defaults = dict(
+        tenant_name="Anna Muster",
+        tenant_address="Teststrasse 1, 8001 Zürich",
+        landlord_name="Verwaltung AG",
+        landlord_address="Bahnhofstrasse 5, 8001 Zürich",
+        property_address="Wohnung 3. OG, Teststrasse 1, 8001 Zürich",
+        analysis=analysis,
+        rent_net=2000,
+        letter_date=datetime.date(2026, 7, 1),
+    )
+    defaults.update(overrides)
+    return HerabsetzungContext(**defaults)
+
+
+def test_render_contains_legal_citations_and_parties():
+    letter = render(_context())
+    for needle in [
+        "Herabsetzungsbegehren",
+        "Art. 269a",
+        "VMWG",
+        "Anna Muster",
+        "Verwaltung AG",
+        "Teststrasse 1",
+        "nächstmöglichen Kündigungstermin",
+        "Einschreiben",
+        "Schlichtungsbehörde",
+        "Teuerung",
+        "1. Juli 2026",
+    ]:
+        assert needle in letter, f"letter missing expected text: {needle}"
+
+
+def test_render_shows_rates_and_amounts():
+    letter = render(_context())
+    assert "1.75" in letter          # base rate
+    assert "1.25" in letter          # current rate
+    assert "5.74" in letter          # permitted reduction %
+    assert "114" in letter           # monthly CHF magnitude
+
+
+def test_render_has_no_unresolved_placeholders():
+    letter = render(_context())
+    assert "{" not in letter
+    assert "}" not in letter
+
+
+def test_render_carries_no_legal_advice_disclaimer():
+    letter = render(_context())
+    assert "keine Rechtsberatung" in letter
+
+
+def test_render_requires_tenant_name():
+    with pytest.raises(ValueError):
+        render(_context(tenant_name="   "))

--- a/apps/api/tests/legal/test_rates.py
+++ b/apps/api/tests/legal/test_rates.py
@@ -1,0 +1,28 @@
+"""Unit tests for the Referenzzinssatz history helpers."""
+import datetime
+
+from strata_api.legal.rates import RATE_HISTORY, latest_rate, rate_at
+
+
+def test_rate_at_returns_effective_rate():
+    assert rate_at(datetime.date(2024, 6, 1)) == 1.75   # between 2023-12 and 2025-03
+    assert rate_at(datetime.date(2025, 6, 1)) == 1.50   # between 2025-03 and 2025-09
+    assert rate_at(datetime.date(2026, 6, 1)) == 1.25   # current era
+
+
+def test_rate_at_before_series_returns_none():
+    assert rate_at(datetime.date(2000, 1, 1)) is None
+
+
+def test_rate_at_accepts_datetime():
+    assert rate_at(datetime.datetime(2024, 6, 1, 12, 0)) == 1.75
+
+
+def test_latest_rate_is_current():
+    assert latest_rate() == 1.25
+    assert RATE_HISTORY[-1][1] == 1.25
+
+
+def test_history_is_ascending_by_date():
+    dates = [entry[0] for entry in RATE_HISTORY]
+    assert dates == sorted(dates)

--- a/apps/api/tests/legal/test_referenzzins.py
+++ b/apps/api/tests/legal/test_referenzzins.py
@@ -1,0 +1,76 @@
+"""Unit tests for Referenzzinssatz rent-adjustment math (OR Art. 269a lit. b).
+
+The permitted rent-change percentages are pinned to the official BWO table so a
+future refactor of the formula cannot silently drift from the published values.
+"""
+import pytest
+
+from strata_api.legal.referenzzins import (
+    RentAnalysis,
+    analyze_rent,
+    monthly_reduction_chf,
+    permitted_change_pct,
+)
+
+
+# ── permitted_change_pct: pinned to the official BWO step table ──
+@pytest.mark.parametrize(
+    "base, current, expected",
+    [
+        (1.75, 1.50, -2.91),   # one 0.25 step down
+        (1.75, 1.25, -5.74),   # two steps down
+        (2.00, 1.25, -8.49),   # three steps down
+        (2.25, 1.25, -11.15),  # four steps down
+        (1.25, 1.50, 3.00),    # one step up (increase)
+        (1.25, 1.75, 6.09),    # two steps up
+        (1.50, 1.50, 0.0),     # no change
+    ],
+)
+def test_permitted_change_pct_matches_bwo_table(base, current, expected):
+    assert permitted_change_pct(base, current) == expected
+
+
+def test_permitted_change_pct_rejects_non_quarter_rate():
+    with pytest.raises(ValueError):
+        permitted_change_pct(1.30, 1.25)
+
+
+def test_permitted_change_pct_rejects_out_of_range():
+    with pytest.raises(ValueError):
+        permitted_change_pct(0.0, 1.25)
+    with pytest.raises(ValueError):
+        permitted_change_pct(8.0, 1.25)
+
+
+# ── monthly_reduction_chf: absolute CHF magnitude of the change ──
+def test_monthly_reduction_chf_reduction():
+    assert monthly_reduction_chf(2000, -2.91) == 58.20
+
+
+def test_monthly_reduction_chf_rejects_negative_rent():
+    with pytest.raises(ValueError):
+        monthly_reduction_chf(-100, -2.91)
+
+
+# ── analyze_rent: full structured result ──
+def test_analyze_rent_reduction():
+    result = analyze_rent(base_rate=1.75, current_rate=1.25, rent_net=2000)
+    assert isinstance(result, RentAnalysis)
+    assert result.change_pct == -5.74
+    assert result.direction == "reduction"
+    assert result.monthly_chf == -114.80    # 2000 * -5.74%
+    assert result.new_rent_net == 1885.20
+
+
+def test_analyze_rent_increase():
+    result = analyze_rent(base_rate=1.25, current_rate=1.75, rent_net=2000)
+    assert result.direction == "increase"
+    assert result.change_pct == 6.09
+
+
+def test_analyze_rent_no_change():
+    result = analyze_rent(base_rate=1.25, current_rate=1.25, rent_net=2000)
+    assert result.direction == "none"
+    assert result.change_pct == 0.0
+    assert result.monthly_chf == 0.0
+    assert result.new_rent_net == 2000.0

--- a/apps/api/tests/routers/test_referenzzins.py
+++ b/apps/api/tests/routers/test_referenzzins.py
@@ -1,0 +1,148 @@
+"""Tests for the /legal Referenzzinssatz + Herabsetzungsbegehren endpoints."""
+import datetime
+from unittest.mock import patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+from sqlalchemy.pool import StaticPool
+
+from strata_api.db import models  # noqa: F401
+from strata_api.db.base import Base
+from strata_api.db.models.listing import Listing
+from strata_api.db.models.reference_rate import ReferenceRate
+from strata_api.main import app
+
+
+@pytest.fixture(scope="module")
+def legal_engine():
+    eng = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(eng)
+    now = datetime.datetime.utcnow()
+    with Session(eng) as s:
+        s.add(ReferenceRate(valid_from=datetime.date(2023, 12, 1), rate_percent=1.75, source="bwo"))
+        s.add(ReferenceRate(valid_from=datetime.date(2025, 3, 3), rate_percent=1.50, source="bwo"))
+        s.add(ReferenceRate(valid_from=datetime.date(2025, 9, 1), rate_percent=1.25, source="bwo"))
+
+        # id 1: explicit base rate 1.75, rent 2000 → 2 steps down vs current 1.25
+        s.add(Listing(
+            id=1, source="flatfox", source_id="L-1",
+            rent_net=2000, base_reference_rate=1.75,
+            street="Teststrasse", house_number="1", plz=8001, city="Zürich",
+            first_seen=datetime.datetime(2024, 6, 1), last_seen=now, is_active=True,
+        ))
+        # id 2: no base rate, first_seen in the 1.50 era (2025-06)
+        s.add(Listing(
+            id=2, source="flatfox", source_id="L-2",
+            rent_net=1800,
+            street="Beispielweg", house_number="2", plz=8004, city="Zürich",
+            first_seen=datetime.datetime(2025, 6, 1), last_seen=now, is_active=True,
+        ))
+        # id 3: no base rate, no rent, first_seen current era (== current rate)
+        s.add(Listing(
+            id=3, source="flatfox", source_id="L-3",
+            street="Leerstrasse", house_number="3", plz=8005, city="Zürich",
+            first_seen=datetime.datetime(2026, 6, 1), last_seen=now, is_active=True,
+        ))
+        s.commit()
+    return eng
+
+
+@pytest.fixture
+async def legal_client(legal_engine):
+    with patch("strata_api.routers.referenzzins.get_engine", return_value=legal_engine):
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+            yield ac
+
+
+async def test_reference_rate_endpoint(legal_client):
+    r = await legal_client.get("/legal/reference-rate")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["current"]["rate_percent"] == 1.25
+    assert len(body["history"]) == 3
+
+
+async def test_rent_analysis_known_base(legal_client):
+    r = await legal_client.get("/legal/listings/1/rent-analysis")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["basis"] == "known"
+    assert body["base_rate"] == 1.75
+    assert body["current_rate"] == 1.25
+    assert body["change_pct"] == -5.74
+    assert body["monthly_chf"] == -114.8
+    assert body["direction"] == "reduction"
+    assert "reduction" in body["message"].lower()
+
+
+async def test_rent_analysis_assumed_from_first_seen(legal_client):
+    r = await legal_client.get("/legal/listings/2/rent-analysis")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["basis"] == "assumed_from_first_seen"
+    assert body["base_rate"] == 1.50
+    assert body["change_pct"] == -2.91
+
+
+async def test_rent_analysis_no_rent_yields_null_chf(legal_client):
+    r = await legal_client.get("/legal/listings/3/rent-analysis")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["direction"] == "none"       # 1.25 base == 1.25 current
+    assert body["monthly_chf"] is None       # no rent_net → no CHF impact
+
+
+async def test_rent_analysis_base_rate_override(legal_client):
+    r = await legal_client.get("/legal/listings/2/rent-analysis?base_rate=2.0")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["basis"] == "override"
+    assert body["base_rate"] == 2.0
+    assert body["change_pct"] == -8.49       # 2.00 → 1.25 = 3 steps
+
+
+async def test_rent_analysis_invalid_base_rate(legal_client):
+    r = await legal_client.get("/legal/listings/2/rent-analysis?base_rate=1.3")
+    assert r.status_code == 422
+
+
+async def test_rent_analysis_unknown_listing(legal_client):
+    r = await legal_client.get("/legal/listings/999/rent-analysis")
+    assert r.status_code == 404
+
+
+async def test_generate_letter(legal_client):
+    payload = {
+        "tenant_name": "Anna Muster",
+        "tenant_address": "Teststrasse 1, 8001 Zürich",
+        "landlord_name": "Verwaltung AG",
+        "landlord_address": "Bahnhofstrasse 5, 8001 Zürich",
+    }
+    r = await legal_client.post("/legal/listings/1/herabsetzungsbegehren", json=payload)
+    assert r.status_code == 200
+    body = r.json()
+    assert "Herabsetzungsbegehren" in body["letter"]
+    assert "Anna Muster" in body["letter"]
+    assert "5.74" in body["letter"]
+
+
+async def test_generate_letter_missing_tenant_name(legal_client):
+    r = await legal_client.post("/legal/listings/1/herabsetzungsbegehren", json={})
+    assert r.status_code == 422
+
+
+async def test_generate_letter_no_reduction_conflict(legal_client):
+    payload = {
+        "tenant_name": "Bea Beispiel",
+        "tenant_address": "Leerstrasse 3, 8005 Zürich",
+        "landlord_name": "Haus AG",
+        "landlord_address": "Weg 1, 8005 Zürich",
+    }
+    r = await legal_client.post("/legal/listings/3/herabsetzungsbegehren", json=payload)
+    assert r.status_code == 409


### PR DESCRIPTION
Closes #17 (backend). First slice of **Layer 7 — Legal Intelligence**.

## What
Monitors the SNB/BWO *hypothekarischer Referenzzinssatz* and computes each listing's rent-reduction entitlement, then generates a ready-to-send **Herabsetzungsbegehren** letter.

## The legal mechanic
Per **OR Art. 269a lit. b** / **VMWG Art. 13**: for reference rates below 5%, each 0.25 pp step = 3% rent change, compounded. Tests are pinned to the official BWO reduction table:

| Steps down | Reduction |
|---|---|
| 1 (e.g. 1.75→1.50) | 2.91% |
| 2 (1.75→1.25) | 5.74% |
| 3 (2.00→1.25) | 8.49% |
| 4 (2.25→1.25) | 11.15% |

> Note: the issue's "×40%" heuristic is imprecise and was **not** used. Offset factors (Teuerung, Kostensteigerungen) are out of scope for v1 and are explicitly reserved in the generated letter.

## Changes
- `legal/referenzzins.py` — pure `permitted_change_pct` + `analyze_rent`
- `legal/rates.py` — documented BWO rate history + `first_seen`→rate inference
- `legal/herabsetzung.py` — German letter renderer (citations, Einschreiben, Schlichtungsbehörde, Teuerung reservation, no-legal-advice disclaimer)
- `db/models/reference_rate.py` + migration `c3f2a1b09e77` (seeds 14 historical rows) + `listings.base_reference_rate` column
- `routers/referenzzins.py` — `GET /legal/reference-rate`, `GET /legal/listings/{id}/rent-analysis`, `POST /legal/listings/{id}/herabsetzungsbegehren`
- `config.default_reference_rate` fallback = **1.25%** (verified vs bwo.admin.ch, June 2026)

## Rate-basis handling
Most scraped listings don't record the rate their rent was set on, so basis is resolved as: `override` (query/body) → `known` (column) → `assumed_from_first_seen` (rate history) → `unknown` (graceful 200, never 500). Letter generation refuses (409) rather than guess when no reduction applies.

## Testing
- 37 new tests; **95%** coverage on new modules
- Full backend suite: **583 passed** (was 546), no regressions
- `alembic upgrade head` / `downgrade -1` verified on fresh SQLite (14 rows seeded)
- `ruff check` clean

## Follow-ups (not in this PR)
- Frontend: rent-analysis badge + one-tap letter in listing cards
- BWO scraper connector + `/admin/pipeline/run-referenzzins` to auto-update the rate
- Wire rate-drop events into the watchlist notification feed

## Test plan
- [ ] Run `uv run alembic upgrade head` against Supabase once deployment is restored
- [ ] Verify current seeded rate (1.25%) against bwo.admin.ch at review time