### PR TITLE
feat: personalized quartier match scoring (#9)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Strata is a spatial intelligence platform for the Zurich housing market. It models every residential unit as a persistent object in a living registry (from the GWR federal register), enriched with listing data scraped from Flatfox/Homegate, neighborhood intelligence, and map visualization. Not a listing platform — housing infrastructure.
 
-**Current Phase:** Phase 0 — Foundation (Apr–May 2026). GWR pipeline, listing ingestion, and proof-of-concept map are built. Remaining: connect to real PostgreSQL (Supabase), deploy, validate against live data.
+**Current Phase:** Layer 1 (Unit Registry) complete; Layer 2 (auth + watchlists + neighborhood intelligence) in progress. Deployment is currently **DOWN** (Supabase paused, Railway credits out). See **`ROADMAP.md`** for the authoritative, up-to-date status of every layer/feature and the current "Next Actions" — read it each session before planning work.
 
 ## Tech Stack
 
@@ -45,7 +45,11 @@ cd apps/api && uv run ruff format .             # auto-format
 ```bash
 cd apps/api && uv run python -m strata_api.pipeline         # GWR pipeline (download + parse + load)
 cd apps/api && uv run python -m strata_api.pipeline.listing_runner  # listing pipeline
+cd apps/api && uv run python -m strata_api.pipeline.neighborhoods            # quartier intelligence → quartiere/noise GeoJSON
+cd apps/api && uv run python -m strata_api.pipeline.neighborhoods --amenities  # also refetch OSM amenities (Overpass); else reuses cached amenities_raw.json
 ```
+
+Commute/isochrone data uses a self-hosted OpenTripPlanner instance — see `scripts/otp/README.md` (docker-compose + GTFS filtering) to stand it up before running the commute pipeline (`pipeline/commute/`).
 
 ### Database migrations (Alembic)
 ```bash
@@ -73,15 +77,17 @@ cd apps/api && DATABASE_URL=... uv run python -m strata_api.scripts.export_listi
 apps/
   web/              Next.js frontend — map is the primary interface
     src/
-      components/map/   Map.tsx (MapLibre), BuildingPopup, Legend, ListingCards, LayerPanel, QuartierProfile
-      lib/              api.ts (fetch wrappers), map/ (era-colors, noise-colors, quartier-colors)
+      components/map/   Map.tsx (MapLibre), BuildingPopup, Legend, ListingCards, LayerPanel, QuartierProfile,
+                        ComparisonPanel (quartier compare), CommuteLegend, TopBar, WatchButton, WatchlistPanel, BarChart
+      components/auth/  AuthControl.tsx (Supabase Auth UI; hidden when env is placeholder)
+      lib/              api.ts (fetch wrappers), supabase.ts (client), quartier-display.ts, time.ts, map/ (era-colors, noise-colors, quartier-colors)
       app/              page.tsx (single-page map app), layout.tsx
   api/              Python backend
     src/strata_api/
       main.py           FastAPI app entry point, mounts routers + static media
       config.py         pydantic-settings (DATABASE_URL, CORS_ORIGINS, PIPELINE_API_KEY)
       db/               SQLAlchemy models (building, unit, entrance, listing, pipeline_run), session factory, Base
-      routers/          registry, listings, neighborhoods, admin_pipeline
+      routers/          registry, listings, neighborhoods, watchlist, admin_pipeline
       pipeline/
         runner.py           GWR pipeline orchestrator (stadt + kanton sources)
         listing_runner.py   Listing pipeline orchestrator
@@ -91,9 +97,10 @@ apps/
         listing_loader.py   Upsert with change detection + deactivation
         loader.py           GWR upsert (buildings, entrances, units)
         dedup.py            Kanton dedup against Stadt EGIDs
-        neighborhoods/      Quartier data: noise, demographics, aggregator
+        neighborhoods/      Quartier intelligence: noise, demographics, amenities (OSM), construction, vibe profiles, aggregator
+        commute/            Quartier→destination commute times via self-hosted OpenTripPlanner
       scripts/          GeoJSON export scripts
-    alembic/            DB migrations (3 versions: initial, listings, listing media)
+    alembic/            DB migrations (5 versions)
     tests/              Mirrors src structure — pipeline/, routers/, db/, fixtures/
     data/               Downloaded media (images, neighborhoods, recon)
 packages/

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -28,7 +28,7 @@ Update this file when phases shift. Claude Code reads it every session via CLAUD
 | Quartiere with profiles | 34 |
 | Noise data points | 1,071,340 |
 | Backend tests | 583 |
-| Frontend tests | 251 |
+| Frontend tests | 286 |
 
 ---
 
@@ -97,7 +97,7 @@ The layer that answers "where should I live?" Four dimensions.
 | Quartier profile panel (slide-out) | 🟢 Done | — |
 | Layer toggle panel | 🟢 Done | — |
 | **Comparison mode** (two Quartiere side by side) | 🟢 Done — compare from profile panel, swap by map click | — |
-| **Personalized match scoring** ("your match: 87%") | 💡 Idea (needs user profiles) | #TBD |
+| **Personalized match scoring** ("your match: 87%") | 🟢 Done — stateless client-side v1: 6 explainable dimensions, localStorage prefs, match choropleth + profile breakdown | #9 |
 
 ---
 

--- a/apps/web/src/components/map/LayerPanel.tsx
+++ b/apps/web/src/components/map/LayerPanel.tsx
@@ -30,6 +30,7 @@ const METRICS: { value: string; label: string }[] = [
   { value: 'foreign_pct', label: 'Foreign residents %' },
   { value: 'age_avg', label: 'Average age' },
   { value: 'growth_rate', label: 'Growth rate' },
+  { value: 'match', label: 'Your match' },
 ];
 
 function isVisible(

--- a/apps/web/src/components/map/Map.tsx
+++ b/apps/web/src/components/map/Map.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { createElement } from 'react';
 import { Legend } from './Legend';
@@ -9,7 +9,8 @@ import { BuildingPopup } from './BuildingPopup';
 import { MapLoadingOverlay } from './MapLoadingOverlay';
 import { PopupSkeleton } from './Skeleton';
 import { LayerPanel } from './LayerPanel';
-import { QuartierProfile } from './QuartierProfile';
+import { QuartierProfile, type QuartierMatch } from './QuartierProfile';
+import { MatchPanel } from './MatchPanel';
 import { ComparisonPanel } from './ComparisonPanel';
 import { CommuteLegend } from './CommuteLegend';
 import { WatchlistPanel } from './WatchlistPanel';
@@ -17,6 +18,13 @@ import { AuthControl } from '../auth/AuthControl';
 import { eraColorExpression } from '@/lib/map/era-colors';
 import { quartierFillColor } from '@/lib/map/quartier-colors';
 import { noiseLineColor } from '@/lib/map/noise-colors';
+import { computeMatchScores, explainMatch, type MatchScoreFeature } from '@/lib/match/score';
+import {
+  DEFAULT_PREFERENCES,
+  loadPreferences,
+  savePreferences,
+  type MatchPreferences,
+} from '@/lib/match/preferences';
 import { COMMUTE_MINUTES_EXPRESSION, COMMUTE_OPACITY_EXPRESSION } from '@/lib/map/commute-colors';
 import {
   fetchBuildingSummary,
@@ -70,6 +78,10 @@ export function MapView() {
   const [quartiereVisible, setQuartiereVisible] = useState(false);
   const [noiseVisible, setNoiseVisible] = useState(false);
   const [activeMetric, setActiveMetric] = useState('population_density');
+
+  // Personalized match scoring (client-side, persisted in localStorage)
+  const [matchPrefs, setMatchPrefs] = useState<MatchPreferences>(DEFAULT_PREFERENCES);
+  const [quartierFeatures, setQuartierFeatures] = useState<MatchScoreFeature[] | null>(null);
 
   // Commute isochrone state
   const [commuteVisible, setCommuteVisible] = useState(false);
@@ -645,6 +657,72 @@ export function MapView() {
     map.setPaintProperty('quartiere-fill', 'fill-color', quartierFillColor(activeMetric));
   }, [activeMetric]);
 
+  // Load persisted match preferences once (client-side only)
+  useEffect(() => {
+    setMatchPrefs(loadPreferences());
+  }, []);
+
+  // Fetch the Quartiere GeoJSON separately so scores can be computed client-side
+  useEffect(() => {
+    let cancelled = false;
+    fetch(QUARTIERE_GEOJSON_URL)
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data: { features?: MatchScoreFeature[] } | null) => {
+        if (cancelled || !data?.features) return;
+        setQuartierFeatures(data.features);
+      })
+      .catch(() => {
+        // Match choropleth simply stays unavailable if the file can't be loaded.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // Recompute match scores whenever features or preferences change
+  const matchScores = useMemo(
+    () => (quartierFeatures ? computeMatchScores(quartierFeatures, matchPrefs) : null),
+    [quartierFeatures, matchPrefs],
+  );
+
+  // Inject match_score into the Quartiere source so the choropleth can read it
+  useEffect(() => {
+    const map = mapRef.current as {
+      getSource?: (id: string) => { setData?: (data: unknown) => void } | undefined;
+    } | null;
+    if (!map?.getSource || !quartierFeatures || !matchScores) return;
+    const augmented = {
+      type: 'FeatureCollection',
+      features: quartierFeatures.map((feature) => ({
+        ...feature,
+        properties: {
+          ...feature.properties,
+          match_score: matchScores.get(feature.properties.quartier_id)?.score ?? -1,
+        },
+      })),
+    };
+    map.getSource?.('quartiere')?.setData?.(augmented);
+  }, [quartierFeatures, matchScores, mapLoaded]);
+
+  // Explain the selected Quartier's match for the profile panel
+  const selectedMatch: QuartierMatch | null = useMemo(() => {
+    if (activeMetric !== 'match' || !quartierProfile || !matchScores) return null;
+    const result = matchScores.get(quartierProfile.quartier_id);
+    if (!result) return null;
+    const { strong, weak } = explainMatch(result.contributions, matchPrefs);
+    return { score: result.score, strong, weak };
+  }, [activeMetric, quartierProfile, matchScores, matchPrefs]);
+
+  const handleMatchChange = useCallback((next: MatchPreferences) => {
+    setMatchPrefs(next);
+    savePreferences(next);
+  }, []);
+
+  const handleMatchReset = useCallback(() => {
+    setMatchPrefs(DEFAULT_PREFERENCES);
+    savePreferences(DEFAULT_PREFERENCES);
+  }, []);
+
   // Popup rendering — re-render with real data once fetched
   useEffect(() => {
     if (!mapRef.current || !popup || !popupCoords) return;
@@ -755,8 +833,8 @@ export function MapView() {
           <WatchlistPanel onClose={() => setWatchlistOpen(false)} />
         </div>
       )}
-      {/* Top-left below TopBar: layer toggles */}
-      <div className="absolute top-20 left-4 z-10 animate-fadeSlideUp">
+      {/* Top-left below TopBar: layer toggles + match preferences */}
+      <div className="absolute top-20 left-4 z-10 flex flex-col gap-3 animate-fadeSlideUp">
         <LayerPanel
           buildingsVisible={buildingsVisible}
           listingsVisible={listingsVisible}
@@ -770,6 +848,13 @@ export function MapView() {
           onCommuteToggle={handleCommuteToggle}
           onDestinationChange={handleDestinationChange}
         />
+        {quartiereVisible && activeMetric === 'match' && (
+          <MatchPanel
+            preferences={matchPrefs}
+            onChange={handleMatchChange}
+            onReset={handleMatchReset}
+          />
+        )}
       </div>
       {/* Bottom-left: legends stacked so they never overlap */}
       <div className="absolute bottom-8 left-4 z-10 flex flex-col gap-3">
@@ -796,6 +881,7 @@ export function MapView() {
             profile={quartierProfile}
             onClose={() => setQuartierProfile(null)}
             onCompare={handleCompareStart}
+            match={selectedMatch}
           />
         </div>
       )}

--- a/apps/web/src/components/map/MatchPanel.test.tsx
+++ b/apps/web/src/components/map/MatchPanel.test.tsx
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MatchPanel } from './MatchPanel';
+import {
+  DEFAULT_PREFERENCES,
+  DIMENSION_LABELS,
+  MATCH_DIMENSIONS,
+  type MatchPreferences,
+} from '@/lib/match/preferences';
+
+const defaultProps = {
+  preferences: DEFAULT_PREFERENCES,
+  onChange: vi.fn(),
+  onReset: vi.fn(),
+};
+
+describe('MatchPanel', () => {
+  it('renders without crashing', () => {
+    render(<MatchPanel {...defaultProps} />);
+  });
+
+  it('applies glass card styling', () => {
+    const { container } = render(<MatchPanel {...defaultProps} />);
+    const card = container.firstChild as HTMLElement;
+    expect(card.className).toContain('strata-panel');
+  });
+
+  it('renders a control for every one of the six dimensions', () => {
+    render(<MatchPanel {...defaultProps} />);
+    for (const dim of MATCH_DIMENSIONS) {
+      expect(screen.getByTestId(`match-dim-${dim}`)).toBeTruthy();
+    }
+  });
+
+  it('renders human-readable labels', () => {
+    render(<MatchPanel {...defaultProps} />);
+    expect(screen.getByText(DIMENSION_LABELS.nightlife)).toBeTruthy();
+    expect(screen.getByText(DIMENSION_LABELS.calm)).toBeTruthy();
+    expect(screen.getByText(DIMENSION_LABELS.upAndComing)).toBeTruthy();
+  });
+
+  it('calls onChange with updated preferences when a control changes', () => {
+    const onChange = vi.fn();
+    render(<MatchPanel {...defaultProps} onChange={onChange} />);
+    // Select "very important" (weight 2) for nightlife
+    fireEvent.click(screen.getByTestId('match-dim-nightlife-weight-2'));
+    expect(onChange).toHaveBeenCalledTimes(1);
+    const updated = onChange.mock.calls[0][0] as MatchPreferences;
+    expect(updated.weights.nightlife).toBe(2);
+    // Other dimensions untouched
+    expect(updated.weights.calm).toBe(1);
+  });
+
+  it('does not mutate the passed preferences object', () => {
+    const onChange = vi.fn();
+    const prefs = DEFAULT_PREFERENCES;
+    render(<MatchPanel {...defaultProps} preferences={prefs} onChange={onChange} />);
+    fireEvent.click(screen.getByTestId('match-dim-nightlife-weight-0'));
+    expect(prefs.weights.nightlife).toBe(1); // original unchanged
+  });
+
+  it('calls onReset when the reset button is clicked', () => {
+    const onReset = vi.fn();
+    render(<MatchPanel {...defaultProps} onReset={onReset} />);
+    fireEvent.click(screen.getByTestId('match-reset'));
+    expect(onReset).toHaveBeenCalledOnce();
+  });
+
+  it('marks the active weight for a dimension', () => {
+    const prefs: MatchPreferences = {
+      weights: { ...DEFAULT_PREFERENCES.weights, nightlife: 2 },
+    };
+    render(<MatchPanel {...defaultProps} preferences={prefs} />);
+    const active = screen.getByTestId('match-dim-nightlife-weight-2');
+    expect(active.getAttribute('aria-pressed')).toBe('true');
+    const inactive = screen.getByTestId('match-dim-nightlife-weight-1');
+    expect(inactive.getAttribute('aria-pressed')).toBe('false');
+  });
+});

--- a/apps/web/src/components/map/MatchPanel.tsx
+++ b/apps/web/src/components/map/MatchPanel.tsx
@@ -1,0 +1,97 @@
+import {
+  DIMENSION_LABELS,
+  MATCH_DIMENSIONS,
+  type MatchDimension,
+  type MatchPreferences,
+} from '@/lib/match/preferences';
+
+interface MatchPanelProps {
+  preferences: MatchPreferences;
+  onChange: (prefs: MatchPreferences) => void;
+  onReset: () => void;
+}
+
+const WEIGHT_OPTIONS: { value: number; label: string; title: string }[] = [
+  { value: 0, label: '–', title: "Don't care" },
+  { value: 1, label: '•', title: 'Matters' },
+  { value: 2, label: '★', title: 'Very important' },
+];
+
+function WeightControl({
+  dimension,
+  weight,
+  onSelect,
+}: {
+  dimension: MatchDimension;
+  weight: number;
+  onSelect: (value: number) => void;
+}) {
+  return (
+    <div
+      className="flex items-center justify-between gap-2"
+      data-testid={`match-dim-${dimension}`}
+    >
+      <span className="flex-1 text-xs-11 text-strata-cream/70">{DIMENSION_LABELS[dimension]}</span>
+      <div className="flex gap-0.5" role="group" aria-label={DIMENSION_LABELS[dimension]}>
+        {WEIGHT_OPTIONS.map(({ value, label, title }) => {
+          const active = weight === value;
+          return (
+            <button
+              key={value}
+              type="button"
+              title={title}
+              aria-pressed={active}
+              data-testid={`match-dim-${dimension}-weight-${value}`}
+              onClick={() => onSelect(value)}
+              className={`h-6 w-6 rounded-md border text-2xs transition-colors duration-150 ${
+                active
+                  ? 'border-strata-amber bg-strata-amber font-medium text-strata-slate-900'
+                  : 'border-strata-cream/15 bg-transparent text-strata-cream/50 hover:border-strata-cream/40 hover:text-strata-cream'
+              }`}
+            >
+              {label}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+export function MatchPanel({ preferences, onChange, onReset }: MatchPanelProps) {
+  function handleSelect(dimension: MatchDimension, value: number) {
+    // Immutable update — never mutate the incoming preferences object.
+    onChange({
+      weights: { ...preferences.weights, [dimension]: value },
+    });
+  }
+
+  return (
+    <div className="strata-panel w-56 p-3.5" data-testid="match-panel">
+      <div className="mb-2.5 flex items-baseline justify-between">
+        <p className="strata-panel-title">Your match</p>
+        <button
+          type="button"
+          onClick={onReset}
+          data-testid="match-reset"
+          className="text-2xs text-strata-cream/40 transition-colors hover:text-strata-cream"
+        >
+          Reset
+        </button>
+      </div>
+      <div className="space-y-1.5">
+        {MATCH_DIMENSIONS.map((dimension) => (
+          <WeightControl
+            key={dimension}
+            dimension={dimension}
+            weight={preferences.weights[dimension]}
+            onSelect={(value) => handleSelect(dimension, value)}
+          />
+        ))}
+      </div>
+      <p className="mt-2.5 text-2xs leading-relaxed text-strata-cream/40">
+        Weight what matters to you. Quartiere are shaded by how well they fit.
+      </p>
+    </div>
+  );
+}

--- a/apps/web/src/components/map/QuartierProfile.test.tsx
+++ b/apps/web/src/components/map/QuartierProfile.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { QuartierProfile } from './QuartierProfile';
 
@@ -6,6 +6,7 @@ const fullProfile = {
   quartier_id: 11,
   quartier_name: 'Rathaus',
   kreis: 1,
+  commute_hb_min: null,
   population: {
     total: 4200,
     density_per_km2: 8400,
@@ -27,6 +28,7 @@ const nullPopulationProfile = {
   quartier_id: 12,
   quartier_name: 'Hochschulen',
   kreis: 1,
+  commute_hb_min: null,
   population: null,
   age_distribution: [],
 };
@@ -134,6 +136,32 @@ describe('QuartierProfile amenities', () => {
   it('omits section when amenities are absent', () => {
     render(<QuartierProfile profile={fullProfile} />);
     expect(screen.queryByTestId('amenities-section')).toBeNull();
+  });
+});
+
+describe('QuartierProfile match score', () => {
+  const match = { score: 72, strong: ['nightlife', 'young & social'], weak: ['calm'] };
+
+  it('renders "Your match: N%" when a score is provided', () => {
+    render(<QuartierProfile profile={fullProfile} match={match} />);
+    expect(screen.getByTestId('match-score')).toBeTruthy();
+    expect(screen.getByTestId('match-score').textContent).toContain('72%');
+  });
+
+  it('renders strong and weak explanation chips', () => {
+    render(<QuartierProfile profile={fullProfile} match={match} />);
+    expect(screen.getByText(/strong on nightlife/i)).toBeTruthy();
+    expect(screen.getByText(/weak on calm/i)).toBeTruthy();
+  });
+
+  it('omits the match line when no match prop is given', () => {
+    render(<QuartierProfile profile={fullProfile} />);
+    expect(screen.queryByTestId('match-score')).toBeNull();
+  });
+
+  it('omits the match line when the score is null', () => {
+    render(<QuartierProfile profile={fullProfile} match={{ score: null, strong: [], weak: [] }} />);
+    expect(screen.queryByTestId('match-score')).toBeNull();
   });
 });
 

--- a/apps/web/src/components/map/QuartierProfile.tsx
+++ b/apps/web/src/components/map/QuartierProfile.tsx
@@ -78,10 +78,48 @@ function AmenitiesSection({ amenities }: { amenities: QuartierAmenities }) {
   );
 }
 
+export interface QuartierMatch {
+  score: number | null;
+  strong: string[];
+  weak: string[];
+}
+
 interface QuartierProfileProps {
   profile: QuartierProfileData;
   onClose?: () => void;
   onCompare?: () => void;
+  match?: QuartierMatch | null;
+}
+
+function MatchSection({ match }: { match: QuartierMatch }) {
+  return (
+    <div className="strata-rule mt-3 pt-3" data-testid="match-score">
+      <div className="flex items-baseline justify-between">
+        <p className="strata-panel-title">Your match</p>
+        <span className="strata-data text-lg-15 font-semibold text-strata-amber">{match.score}%</span>
+      </div>
+      {(match.strong.length > 0 || match.weak.length > 0) && (
+        <div className="mt-1.5 flex flex-wrap gap-1.5">
+          {match.strong.map((label) => (
+            <span
+              key={`strong-${label}`}
+              className="rounded-full border border-strata-sage/30 px-2 py-0.5 text-2xs text-strata-sage"
+            >
+              strong on {label}
+            </span>
+          ))}
+          {match.weak.map((label) => (
+            <span
+              key={`weak-${label}`}
+              className="rounded-full border border-strata-cream/12 px-2 py-0.5 text-2xs text-strata-cream/45"
+            >
+              weak on {label}
+            </span>
+          ))}
+        </div>
+      )}
+    </div>
+  );
 }
 
 const TREND_STYLES: Record<QuartierPopulation['trend'], { arrow: string; className: string }> = {
@@ -111,7 +149,7 @@ function StatRow({ label, children }: { label: string; children: React.ReactNode
   );
 }
 
-export function QuartierProfile({ profile, onClose, onCompare }: QuartierProfileProps) {
+export function QuartierProfile({ profile, onClose, onCompare, match }: QuartierProfileProps) {
   const {
     quartier_name,
     kreis,
@@ -147,6 +185,8 @@ export function QuartierProfile({ profile, onClose, onCompare }: QuartierProfile
       </div>
 
       {vibe && <VibeSection vibe={vibe} />}
+
+      {match && match.score !== null && <MatchSection match={match} />}
 
       {population === null ? (
         <p className="text-xs-11 italic text-strata-cream/40">No data</p>

--- a/apps/web/src/lib/map/quartier-colors.test.ts
+++ b/apps/web/src/lib/map/quartier-colors.test.ts
@@ -51,6 +51,15 @@ describe('quartierFillColor', () => {
     expect(Array.isArray(expr)).toBe(true);
   });
 
+  it('returns a MapLibre expression referencing match_score for the match metric', async () => {
+    const { quartierFillColor } = await import('./quartier-colors');
+    const expr = quartierFillColor('match');
+    expect(Array.isArray(expr)).toBe(true);
+    const str = JSON.stringify(expr);
+    expect(str).toContain('match_score');
+    expect(str).toMatch(/#[0-9a-fA-F]{6}/);
+  });
+
   it('expression contains color strings (hex)', async () => {
     const { quartierFillColor } = await import('./quartier-colors');
     const expr = quartierFillColor('population_density');

--- a/apps/web/src/lib/map/quartier-colors.ts
+++ b/apps/web/src/lib/map/quartier-colors.ts
@@ -44,6 +44,15 @@ const GROWTH_RATE_STOPS: [number, string][] = [
   [3, '#00c853'],
 ];
 
+// Personalized match score (0..100): Viridis (poor fit → great fit)
+const MATCH_STOPS: [number, string][] = [
+  [0, '#440154'],
+  [25, '#3b528b'],
+  [50, '#21918c'],
+  [75, '#5ec962'],
+  [90, '#fde725'],
+];
+
 function _stepExpression(
   property: string,
   stops: [number, string][],
@@ -68,6 +77,7 @@ function _stepExpression(
  *   - "foreign_pct"        — percentage of foreign residents
  *   - "age_avg"            — average age proxy
  *   - "growth_rate"        — year-over-year growth rate
+ *   - "match"              — personalized match score (reads `match_score`)
  *
  * Unknown metrics fall back to the population_density expression.
  */
@@ -81,6 +91,8 @@ export function quartierFillColor(metric: Metric): unknown[] {
       return _stepExpression('age_avg', AGE_AVG_STOPS);
     case 'growth_rate':
       return _stepExpression('growth_rate', GROWTH_RATE_STOPS);
+    case 'match':
+      return _stepExpression('match_score', MATCH_STOPS);
     default:
       return _stepExpression('population_density', DENSITY_STOPS);
   }

--- a/apps/web/src/lib/match/preferences.test.ts
+++ b/apps/web/src/lib/match/preferences.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import {
+  DEFAULT_PREFERENCES,
+  MATCH_DIMENSIONS,
+  hasActivePreferences,
+  loadPreferences,
+  savePreferences,
+  type MatchPreferences,
+} from './preferences';
+
+const STORAGE_KEY = 'strata.match.preferences.v1';
+
+describe('DEFAULT_PREFERENCES', () => {
+  it('assigns weight 1 to every dimension', () => {
+    for (const dim of MATCH_DIMENSIONS) {
+      expect(DEFAULT_PREFERENCES.weights[dim]).toBe(1);
+    }
+  });
+});
+
+describe('preferences persistence', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('returns defaults when nothing is stored', () => {
+    expect(loadPreferences()).toEqual(DEFAULT_PREFERENCES);
+  });
+
+  it('round-trips saved preferences', () => {
+    const prefs: MatchPreferences = {
+      weights: { nightlife: 2, dailyNeeds: 0, calm: 1, family: 2, youngSocial: 0, upAndComing: 1 },
+    };
+    savePreferences(prefs);
+    expect(loadPreferences()).toEqual(prefs);
+  });
+
+  it('falls back to defaults on corrupted JSON', () => {
+    window.localStorage.setItem(STORAGE_KEY, '{not valid json');
+    expect(loadPreferences()).toEqual(DEFAULT_PREFERENCES);
+  });
+
+  it('merges missing keys with defaults', () => {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify({ weights: { nightlife: 2 } }));
+    const loaded = loadPreferences();
+    expect(loaded.weights.nightlife).toBe(2);
+    expect(loaded.weights.calm).toBe(1);
+    expect(loaded.weights.upAndComing).toBe(1);
+  });
+
+  it('clamps out-of-range and non-numeric weights', () => {
+    window.localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ weights: { nightlife: 99, dailyNeeds: -5, calm: 'x' } }),
+    );
+    const loaded = loadPreferences();
+    expect(loaded.weights.nightlife).toBe(2);
+    expect(loaded.weights.dailyNeeds).toBe(0);
+    expect(loaded.weights.calm).toBe(1); // invalid → default
+  });
+});
+
+describe('SSR guard', () => {
+  const original = globalThis.window;
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    (globalThis as { window?: unknown }).window = original;
+  });
+
+  it('loadPreferences returns defaults without a window', () => {
+    vi.stubGlobal('window', undefined);
+    expect(loadPreferences()).toEqual(DEFAULT_PREFERENCES);
+  });
+
+  it('savePreferences does not throw without a window', () => {
+    vi.stubGlobal('window', undefined);
+    expect(() => savePreferences(DEFAULT_PREFERENCES)).not.toThrow();
+  });
+});
+
+describe('hasActivePreferences', () => {
+  it('is true when any weight is non-zero', () => {
+    expect(hasActivePreferences(DEFAULT_PREFERENCES)).toBe(true);
+  });
+
+  it('is false when all weights are zero', () => {
+    const allZero: MatchPreferences = {
+      weights: { nightlife: 0, dailyNeeds: 0, calm: 0, family: 0, youngSocial: 0, upAndComing: 0 },
+    };
+    expect(hasActivePreferences(allZero)).toBe(false);
+  });
+});

--- a/apps/web/src/lib/match/preferences.ts
+++ b/apps/web/src/lib/match/preferences.ts
@@ -1,0 +1,110 @@
+/**
+ * Personalized match preferences — persisted client-side in localStorage.
+ *
+ * A preference is a per-dimension weight in the range 0..2:
+ *   0 = don't care · 1 = matters · 2 = very important.
+ *
+ * Nothing here touches the DOM directly beyond guarded localStorage access,
+ * and every read validates untrusted stored data before use.
+ */
+
+export const MATCH_DIMENSIONS = [
+  'nightlife',
+  'dailyNeeds',
+  'calm',
+  'family',
+  'youngSocial',
+  'upAndComing',
+] as const;
+
+export type MatchDimension = (typeof MATCH_DIMENSIONS)[number];
+
+/** Human-readable panel labels for each dimension. */
+export const DIMENSION_LABELS: Record<MatchDimension, string> = {
+  nightlife: 'Nightlife & cafés',
+  dailyNeeds: 'Daily needs',
+  calm: 'Calm',
+  family: 'Family-friendly',
+  youngSocial: 'Young & social',
+  upAndComing: 'Up-and-coming',
+};
+
+/** Short labels used in explanation chips ("strong on nightlife"). */
+export const DIMENSION_SHORT_LABELS: Record<MatchDimension, string> = {
+  nightlife: 'nightlife',
+  dailyNeeds: 'daily needs',
+  calm: 'calm',
+  family: 'family',
+  youngSocial: 'young & social',
+  upAndComing: 'up-and-coming',
+};
+
+export const MIN_WEIGHT = 0;
+export const MAX_WEIGHT = 2;
+export const DEFAULT_WEIGHT = 1;
+
+export interface MatchPreferences {
+  weights: Record<MatchDimension, number>;
+}
+
+export const DEFAULT_PREFERENCES: MatchPreferences = {
+  weights: {
+    nightlife: DEFAULT_WEIGHT,
+    dailyNeeds: DEFAULT_WEIGHT,
+    calm: DEFAULT_WEIGHT,
+    family: DEFAULT_WEIGHT,
+    youngSocial: DEFAULT_WEIGHT,
+    upAndComing: DEFAULT_WEIGHT,
+  },
+};
+
+const STORAGE_KEY = 'strata.match.preferences.v1';
+
+/** Coerce an untrusted value into a valid weight, falling back to the default. */
+function sanitizeWeight(value: unknown): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return DEFAULT_WEIGHT;
+  return Math.min(MAX_WEIGHT, Math.max(MIN_WEIGHT, value));
+}
+
+/** Merge an untrusted object with defaults — never trust stored data. */
+function mergeWithDefaults(raw: unknown): MatchPreferences {
+  const source =
+    raw && typeof raw === 'object' && 'weights' in raw
+      ? (raw as { weights?: unknown }).weights
+      : undefined;
+  const weightsSource =
+    source && typeof source === 'object' ? (source as Record<string, unknown>) : {};
+
+  const weights = {} as Record<MatchDimension, number>;
+  for (const dim of MATCH_DIMENSIONS) {
+    weights[dim] = sanitizeWeight(weightsSource[dim]);
+  }
+  return { weights };
+}
+
+/** Load preferences from localStorage, falling back to defaults on any error. */
+export function loadPreferences(): MatchPreferences {
+  if (typeof window === 'undefined') return DEFAULT_PREFERENCES;
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return DEFAULT_PREFERENCES;
+    return mergeWithDefaults(JSON.parse(raw));
+  } catch {
+    return DEFAULT_PREFERENCES;
+  }
+}
+
+/** Persist preferences to localStorage. No-op during SSR or on storage errors. */
+export function savePreferences(prefs: MatchPreferences): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(prefs));
+  } catch {
+    // Storage may be unavailable (private mode, quota) — ignore silently.
+  }
+}
+
+/** True when at least one dimension has a non-zero weight. */
+export function hasActivePreferences(prefs: MatchPreferences): boolean {
+  return MATCH_DIMENSIONS.some((dim) => prefs.weights[dim] > 0);
+}

--- a/apps/web/src/lib/match/score.test.ts
+++ b/apps/web/src/lib/match/score.test.ts
@@ -1,0 +1,194 @@
+import { describe, it, expect } from 'vitest';
+import {
+  computeMatchScores,
+  explainMatch,
+  MATCH_DIMENSIONS,
+  type MatchScoreFeature,
+} from './score';
+import { DEFAULT_PREFERENCES, type MatchPreferences } from './preferences';
+
+/** Build a fake quartier GeoJSON feature with area_km2 = 1 so per-km² == raw count. */
+function feat(
+  id: number,
+  o: {
+    pop?: number;
+    growth?: number;
+    a017?: number;
+    a1829?: number;
+    bars?: number;
+    cafes?: number;
+    rest?: number;
+    groc?: number;
+    pharm?: number;
+    appr?: number;
+    start?: number;
+    area?: number;
+    amenities?: unknown;
+  },
+): MatchScoreFeature {
+  return {
+    type: 'Feature',
+    properties: {
+      quartier_id: id,
+      area_km2: o.area ?? 1,
+      population_density: o.pop ?? 0,
+      growth_rate: o.growth ?? 0,
+      age_0_17_pct: o.a017 ?? 0,
+      age_18_29_pct: o.a1829 ?? 0,
+      amenities:
+        'amenities' in o
+          ? (o.amenities as never)
+          : {
+              bars: o.bars ?? 0,
+              cafes: o.cafes ?? 0,
+              restaurants: o.rest ?? 0,
+              groceries: o.groc ?? 0,
+              pharmacies: o.pharm ?? 0,
+            },
+      construction: { approved_projects: o.appr ?? 0, started_projects: o.start ?? 0 },
+    },
+  } as MatchScoreFeature;
+}
+
+// Hand-built fixture. area = 1 for all, so densities equal raw counts.
+//   A: venue 0,  daily 10, pop 0,     a017 20, a1829 0,  growth 0, constr 0
+//   B: venue 5,  daily 5,  pop 5000,  a017 10, a1829 10, growth 1, constr 5
+//   C: venue 10, daily 0,  pop 10000, a017 0,  a1829 20, growth 2, constr 10
+const FIXTURE: MatchScoreFeature[] = [
+  feat(1, { bars: 0, cafes: 0, rest: 0, groc: 10, pharm: 0, pop: 0, a017: 20, a1829: 0, growth: 0, appr: 0, start: 0 }),
+  feat(2, { bars: 1, cafes: 2, rest: 2, groc: 5, pharm: 0, pop: 5000, a017: 10, a1829: 10, growth: 1, appr: 2, start: 3 }),
+  feat(3, { bars: 2, cafes: 4, rest: 4, groc: 0, pharm: 0, pop: 10000, a017: 0, a1829: 20, growth: 2, appr: 4, start: 6 }),
+];
+
+const weights = (partial: Partial<Record<string, number>>): MatchPreferences => ({
+  weights: { ...DEFAULT_PREFERENCES.weights, ...partial } as MatchPreferences['weights'],
+});
+
+describe('computeMatchScores', () => {
+  it('returns a score + contributions per quartier keyed by quartier_id', () => {
+    const scores = computeMatchScores(FIXTURE, DEFAULT_PREFERENCES);
+    expect(scores.size).toBe(3);
+    expect(scores.get(1)).toBeDefined();
+    expect(scores.get(3)?.contributions).toBeDefined();
+  });
+
+  it('min-max normalizes: max→1, min→0 for a dimension', () => {
+    const scores = computeMatchScores(FIXTURE, DEFAULT_PREFERENCES);
+    // nightlife (venue density): C is max, A is min
+    expect(scores.get(3)?.contributions.nightlife).toBeCloseTo(1);
+    expect(scores.get(1)?.contributions.nightlife).toBeCloseTo(0);
+    // dailyNeeds: A is max, C is min
+    expect(scores.get(1)?.contributions.dailyNeeds).toBeCloseTo(1);
+    expect(scores.get(3)?.contributions.dailyNeeds).toBeCloseTo(0);
+  });
+
+  it('produces the hand-computed contributions for feature C', () => {
+    const c = computeMatchScores(FIXTURE, DEFAULT_PREFERENCES).get(3)!;
+    expect(c.contributions.nightlife).toBeCloseTo(1);
+    expect(c.contributions.dailyNeeds).toBeCloseTo(0);
+    expect(c.contributions.calm).toBeCloseTo(0);
+    expect(c.contributions.family).toBeCloseTo(0);
+    expect(c.contributions.youngSocial).toBeCloseTo(1);
+    expect(c.contributions.upAndComing).toBeCloseTo(1);
+  });
+
+  it('all-equal inputs normalize every dimension to 0.5', () => {
+    const equal = [feat(1, { bars: 3, cafes: 3, rest: 3, groc: 2, pharm: 2, pop: 4000, a017: 15, a1829: 15, growth: 1, appr: 1, start: 1 })];
+    const c = computeMatchScores(equal, DEFAULT_PREFERENCES).get(1)!;
+    for (const d of MATCH_DIMENSIONS) {
+      expect(c.contributions[d]).toBeCloseTo(0.5);
+    }
+    expect(c.score).toBe(50);
+  });
+
+  it('scores every fixture quartier at 50% with default (all-equal) weights', () => {
+    const scores = computeMatchScores(FIXTURE, DEFAULT_PREFERENCES);
+    expect(scores.get(1)?.score).toBe(50);
+    expect(scores.get(2)?.score).toBe(50);
+    expect(scores.get(3)?.score).toBe(50);
+  });
+
+  it('applies weighted mean and excludes weight-0 dimensions', () => {
+    // nightlife weight 2, calm weight 0, all others weight 1
+    const prefs = weights({ nightlife: 2, calm: 0 });
+    // Feature C: nightlife=1(w2), dailyNeeds=0(w1), family=0(w1), youngSocial=1(w1), upAndComing=1(w1)
+    // weighted sum = 2*1 + 0 + 0 + 1 + 1 = 4 ; weight sum = 2+1+1+1+1 = 6 → 66.67 → 67
+    expect(computeMatchScores(FIXTURE, prefs).get(3)?.score).toBe(67);
+    // Feature A: nightlife=0(w2), dailyNeeds=1(w1), family=1(w1), youngSocial=0, upAndComing=0
+    // weighted sum = 0 + 1 + 1 + 0 + 0 = 2 ; weight sum = 6 → 33.33 → 33
+    expect(computeMatchScores(FIXTURE, prefs).get(1)?.score).toBe(33);
+  });
+
+  it('returns null score when all weights are 0', () => {
+    const prefs = weights({
+      nightlife: 0,
+      dailyNeeds: 0,
+      calm: 0,
+      family: 0,
+      youngSocial: 0,
+      upAndComing: 0,
+    });
+    expect(computeMatchScores(FIXTURE, prefs).get(1)?.score).toBeNull();
+  });
+
+  it('never produces NaN when amenities are missing or area_km2 is 0', () => {
+    const broken: MatchScoreFeature[] = [
+      feat(10, { amenities: undefined, area: 0, pop: 1000, a017: 10, a1829: 10, growth: 1, appr: 0, start: 0 }),
+      feat(11, { bars: 5, cafes: 5, rest: 5, groc: 3, pharm: 1, pop: 8000, a017: 20, a1829: 25, growth: 2, appr: 3, start: 2 }),
+    ];
+    const scores = computeMatchScores(broken, DEFAULT_PREFERENCES);
+    for (const [, v] of scores) {
+      expect(v.score === null || Number.isFinite(v.score)).toBe(true);
+      for (const d of MATCH_DIMENSIONS) {
+        expect(Number.isFinite(v.contributions[d])).toBe(true);
+      }
+    }
+  });
+
+  it('does not mutate the input features', () => {
+    const snapshot = JSON.stringify(FIXTURE);
+    computeMatchScores(FIXTURE, DEFAULT_PREFERENCES);
+    expect(JSON.stringify(FIXTURE)).toBe(snapshot);
+  });
+});
+
+describe('explainMatch', () => {
+  const contributions = {
+    nightlife: 0.9,
+    dailyNeeds: 0.1,
+    calm: 0.5,
+    family: 0.8,
+    youngSocial: 0.3,
+    upAndComing: 0.2,
+  };
+
+  it('returns the top-2 strongest and bottom-2 weakest dimensions', () => {
+    const { strong, weak } = explainMatch(contributions, DEFAULT_PREFERENCES);
+    expect(strong).toEqual(['nightlife', 'family']);
+    expect(weak).toEqual(['daily needs', 'up-and-coming']);
+  });
+
+  it('excludes weight-0 dimensions from strong and weak', () => {
+    const prefs = weights({ upAndComing: 0 });
+    const { strong, weak } = explainMatch(contributions, prefs);
+    expect(strong).toEqual(['nightlife', 'family']);
+    expect(weak).not.toContain('up-and-coming');
+    expect(weak).toEqual(['daily needs', 'young & social']);
+  });
+
+  it('does not overlap strong and weak when few dimensions are active', () => {
+    const prefs = weights({
+      nightlife: 1,
+      family: 1,
+      dailyNeeds: 0,
+      calm: 0,
+      youngSocial: 0,
+      upAndComing: 0,
+    });
+    const { strong, weak } = explainMatch(contributions, prefs);
+    expect(strong).toEqual(['nightlife', 'family']);
+    for (const label of weak) {
+      expect(strong).not.toContain(label);
+    }
+  });
+});

--- a/apps/web/src/lib/match/score.ts
+++ b/apps/web/src/lib/match/score.ts
@@ -1,0 +1,192 @@
+/**
+ * Pure, explainable per-Quartier match scoring.
+ *
+ * Every score is derived from six normalized dimensions (each 0..1, min-max
+ * normalized across the supplied Quartiere) combined via a weighted mean of the
+ * user's preferences. No DOM, no fetch, no mutation of inputs.
+ */
+
+import {
+  MATCH_DIMENSIONS,
+  DIMENSION_SHORT_LABELS,
+  type MatchDimension,
+  type MatchPreferences,
+} from './preferences';
+
+export { MATCH_DIMENSIONS, type MatchDimension };
+
+interface Amenities {
+  bars?: number;
+  cafes?: number;
+  restaurants?: number;
+  groceries?: number;
+  pharmacies?: number;
+  [key: string]: unknown;
+}
+
+interface Construction {
+  approved_projects?: number;
+  started_projects?: number;
+  [key: string]: unknown;
+}
+
+export interface MatchScoreProperties {
+  quartier_id: number;
+  area_km2?: number;
+  population_density?: number;
+  growth_rate?: number;
+  age_0_17_pct?: number;
+  age_18_29_pct?: number;
+  amenities?: Amenities | null;
+  construction?: Construction | null;
+}
+
+export interface MatchScoreFeature {
+  type?: string;
+  properties: MatchScoreProperties;
+}
+
+export interface MatchResult {
+  /** Whole-percent match score, or null when all weights are 0. */
+  score: number | null;
+  /** Per-dimension value in 0..1 used to explain the score. */
+  contributions: Record<MatchDimension, number>;
+}
+
+/** Safe numeric coercion — non-finite or non-number values become 0. */
+function num(value: unknown): number {
+  return typeof value === 'number' && Number.isFinite(value) ? value : 0;
+}
+
+/** Per-km² density, guarding against a zero/absent area (returns 0, never NaN). */
+function perKm2(count: number, area: number): number {
+  return area > 0 ? count / area : 0;
+}
+
+/** Base (pre-normalization) metrics extracted from a single feature. */
+interface BaseMetrics {
+  venueDensity: number;
+  dailyDensity: number;
+  popDensity: number;
+  family: number;
+  youngSocial: number;
+  growth: number;
+  constructionDensity: number;
+}
+
+function extractBaseMetrics(feature: MatchScoreFeature): BaseMetrics {
+  const p = feature.properties;
+  const a: Amenities = p.amenities ?? {};
+  const c: Construction = p.construction ?? {};
+  const area = num(p.area_km2);
+
+  const venues = num(a.bars) + num(a.cafes) + num(a.restaurants);
+  const daily = num(a.groceries) + num(a.pharmacies);
+  const projects = num(c.approved_projects) + num(c.started_projects);
+
+  return {
+    venueDensity: perKm2(venues, area),
+    dailyDensity: perKm2(daily, area),
+    popDensity: num(p.population_density),
+    family: num(p.age_0_17_pct),
+    youngSocial: num(p.age_18_29_pct),
+    growth: num(p.growth_rate),
+    constructionDensity: perKm2(projects, area),
+  };
+}
+
+/** Min-max normalize an array to 0..1; all-equal inputs collapse to 0.5. */
+function minMax(values: number[]): number[] {
+  if (values.length === 0) return [];
+  const min = Math.min(...values);
+  const max = Math.max(...values);
+  const span = max - min;
+  if (span === 0) return values.map(() => 0.5);
+  return values.map((v) => (v - min) / span);
+}
+
+/**
+ * Compute match scores for every feature.
+ * Returns a Map keyed by quartier_id → { score, contributions }.
+ */
+export function computeMatchScores(
+  features: readonly MatchScoreFeature[],
+  prefs: MatchPreferences,
+): Map<number, MatchResult> {
+  const base = features.map(extractBaseMetrics);
+
+  const normVenue = minMax(base.map((b) => b.venueDensity));
+  const normDaily = minMax(base.map((b) => b.dailyDensity));
+  const normPop = minMax(base.map((b) => b.popDensity));
+  const normFamily = minMax(base.map((b) => b.family));
+  const normYoung = minMax(base.map((b) => b.youngSocial));
+  const normGrowth = minMax(base.map((b) => b.growth));
+  const normConstruction = minMax(base.map((b) => b.constructionDensity));
+
+  const results = new Map<number, MatchResult>();
+
+  features.forEach((feature, i) => {
+    const contributions: Record<MatchDimension, number> = {
+      nightlife: normVenue[i],
+      dailyNeeds: normDaily[i],
+      // "calm" is an honest proxy: inverse of combined venue + population density.
+      calm: 1 - (0.5 * normVenue[i] + 0.5 * normPop[i]),
+      family: normFamily[i],
+      youngSocial: normYoung[i],
+      upAndComing: 0.5 * normGrowth[i] + 0.5 * normConstruction[i],
+    };
+    results.set(feature.properties.quartier_id, {
+      score: weightedScore(contributions, prefs),
+      contributions,
+    });
+  });
+
+  return results;
+}
+
+/** Weighted mean of dimension values × 100, rounded. Null when all weights 0. */
+function weightedScore(
+  contributions: Record<MatchDimension, number>,
+  prefs: MatchPreferences,
+): number | null {
+  let weightSum = 0;
+  let valueSum = 0;
+  for (const dim of MATCH_DIMENSIONS) {
+    const weight = prefs.weights[dim];
+    if (weight > 0) {
+      weightSum += weight;
+      valueSum += weight * contributions[dim];
+    }
+  }
+  if (weightSum === 0) return null;
+  return Math.round((valueSum / weightSum) * 100);
+}
+
+export interface MatchExplanation {
+  /** Short labels of the strongest dimensions (weight > 0), strongest first. */
+  strong: string[];
+  /** Short labels of the weakest dimensions (weight > 0), weakest first. */
+  weak: string[];
+}
+
+/**
+ * Surface the top-2 strongest and bottom-2 weakest dimensions among those the
+ * user cares about (weight > 0). Strong and weak never overlap.
+ */
+export function explainMatch(
+  contributions: Record<MatchDimension, number>,
+  prefs: MatchPreferences,
+): MatchExplanation {
+  const active = MATCH_DIMENSIONS.filter((dim) => prefs.weights[dim] > 0).sort(
+    (a, b) => contributions[b] - contributions[a],
+  );
+
+  const strong = active.slice(0, 2);
+  // Start weak after the strong slice so the two sets never overlap.
+  const weak = active.slice(Math.max(2, active.length - 2)).reverse();
+
+  return {
+    strong: strong.map((dim) => DIMENSION_SHORT_LABELS[dim]),
+    weak: weak.map((dim) => DIMENSION_SHORT_LABELS[dim]),
+  };
+}


### PR DESCRIPTION
Closes #9. Layer 1 Neighborhood Features — the "your match: 87%" from the vision doc.

## Product decision
The issue said this "depends on user profiles (auth)". **Overridden**: v1 is stateless and client-side — preferences live in localStorage, scores are computed in the browser from the already-shipped `quartiere.geojson` (34 quartiere). This honors the vision's core anti-pattern ("never gate exploration behind data collection") and ships value while prod deployment is down. Profile-backed scoring can layer on top later without rework.

## Scoring model (explainable by construction)
6 dimensions, each min-max normalized across the 34 quartiere:
| Dimension | Source |
|---|---|
| Nightlife & cafés | (bars + cafés + restaurants) / km² |
| Daily needs | (groceries + pharmacies) / km² |
| Calm *(proxy)* | inverse of venue + population density (real noise data later) |
| Family-friendly | age 0–17 % |
| Young & social | age 18–29 % |
| Up-and-coming | growth rate + construction projects / km² |

Weights 0/1/2 per dimension (default 1). Score = weighted mean × 100. All-zero weights → no score. Per-dimension contributions surface as "strong on nightlife / weak on calm" chips — every score is explainable, per the vision's transparency principle.

## UI
- **MatchPanel** — segmented 0/1/2 weight control per dimension + reset, glass styling
- **"Your match" choropleth** — new metric in LayerPanel; scores injected into the quartiere source client-side (Viridis scale)
- **QuartierProfile** — "Your match: N%" + strong/weak chips when active

## Implementation notes
- Built TDD by an Opus 4.8 agent, reviewed and shipped by the session orchestrator (autonomous dev loop, iteration 2)
- Pure scoring lib (`lib/match/score.ts`) — no DOM, no fetch, no mutation; robust to missing amenities/construction and `area_km2 = 0` (no NaN)
- localStorage reads validated + clamped (never trust stored data), SSR-guarded
- GeoJSON fetch failure degrades gracefully (choropleth stays flat)

## Testing
- **+35 tests → 286 total, all green** (score: 12, preferences: 10, MatchPanel: 8, quartier-colors: +1, QuartierProfile: +4)
- `npm run lint` clean (0 errors; 2 pre-existing warnings untouched)
- New code type-checks clean; 3 pre-existing tsc errors in commute test files are untouched and tracked for a follow-up chore

## Test plan
- [ ] Toggle "Your match" metric, adjust weights, confirm choropleth recolors live
- [ ] Reload page — preferences persist
- [ ] Click a quartier with match metric active — profile shows score + chips