### PR TITLE
feat: rent-reduction badge + Herabsetzungsbegehren dialog in listing cards

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -28,7 +28,7 @@ Update this file when phases shift. Claude Code reads it every session via CLAUD
 | Quartiere with profiles | 34 |
 | Noise data points | 1,071,340 |
 | Backend tests | 583 |
-| Frontend tests | 286 |
+| Frontend tests | 314 |
 
 ---
 
@@ -174,8 +174,8 @@ The layer that answers "where should I live?" Four dimensions.
 
 | Component | Status | Issue |
 |-----------|--------|-------|
-| Referenzzinssatz auto-tracking | 🟢 Backend done — history table + `/legal/reference-rate`, per-listing analysis (OR 269a step table) | #17 |
-| Pre-drafted Herabsetzungsbegehren | 🟢 Backend done — `POST /legal/listings/{id}/herabsetzungsbegehren` | #17 |
+| Referenzzinssatz auto-tracking | 🟢 Done — history table + `/legal/reference-rate`, per-listing analysis (OR 269a step table), badge in listing cards | #17 |
+| Pre-drafted Herabsetzungsbegehren | 🟢 Done — API + one-tap letter dialog (copy/download) in listing cards | #17 |
 | Initial rent challenge analysis (OR Art. 270) | ⚪ Planned | #TBD |
 | Rent increase verification | ⚪ Planned | #TBD |
 | Mängelrüge templates | 💡 Idea | #TBD |

--- a/apps/web/src/components/listings/HerabsetzungDialog.test.tsx
+++ b/apps/web/src/components/listings/HerabsetzungDialog.test.tsx
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { HerabsetzungDialog } from './HerabsetzungDialog';
+
+vi.mock('@/lib/api', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/api')>();
+  return {
+    ...actual,
+    generateHerabsetzung: vi.fn(),
+  };
+});
+
+import { generateHerabsetzung } from '@/lib/api';
+
+const mockGenerate = vi.mocked(generateHerabsetzung);
+
+beforeEach(() => {
+  mockGenerate.mockReset();
+});
+
+function fillTenantName(value = 'Anna Muster') {
+  fireEvent.change(screen.getByTestId('field-tenant-name'), { target: { value } });
+}
+
+describe('HerabsetzungDialog', () => {
+  it('shows a validation message when tenant name is empty on submit', async () => {
+    render(<HerabsetzungDialog listingId={42} onClose={() => {}} />);
+
+    fireEvent.click(screen.getByTestId('herabsetzung-submit'));
+
+    expect(screen.getByTestId('herabsetzung-error').textContent).toBeTruthy();
+    expect(mockGenerate).not.toHaveBeenCalled();
+  });
+
+  it('submits and renders the returned letter text', async () => {
+    mockGenerate.mockResolvedValueOnce({
+      status: 'ok',
+      data: { listing_id: 42, basis: 'known', letter: 'Sehr geehrte Damen und Herren, Herabsetzung.' },
+    });
+    render(<HerabsetzungDialog listingId={42} onClose={() => {}} />);
+
+    fillTenantName();
+    fireEvent.click(screen.getByTestId('herabsetzung-submit'));
+
+    const letter = await screen.findByTestId('herabsetzung-letter');
+    expect(letter.textContent).toContain('Herabsetzung');
+    expect(mockGenerate).toHaveBeenCalledWith(42, expect.objectContaining({ tenant_name: 'Anna Muster' }));
+  });
+
+  it('shows a friendly German message on a 409 no_reduction result', async () => {
+    mockGenerate.mockResolvedValueOnce({ status: 'no_reduction' });
+    render(<HerabsetzungDialog listingId={42} onClose={() => {}} />);
+
+    fillTenantName();
+    fireEvent.click(screen.getByTestId('herabsetzung-submit'));
+
+    const err = await screen.findByTestId('herabsetzung-error');
+    expect(err.textContent).toMatch(/keine|kein|Mietzinssenkung/i);
+    expect(screen.queryByTestId('herabsetzung-letter')).toBeNull();
+  });
+
+  it('shows an inline error message when the request throws (validation)', async () => {
+    mockGenerate.mockRejectedValueOnce(new Error('tenant_name is required'));
+    render(<HerabsetzungDialog listingId={42} onClose={() => {}} />);
+
+    fillTenantName();
+    fireEvent.click(screen.getByTestId('herabsetzung-submit'));
+
+    const err = await screen.findByTestId('herabsetzung-error');
+    expect(err.textContent).toContain('tenant_name is required');
+  });
+
+  it('copies the letter to the clipboard when Copy is clicked', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText } });
+
+    mockGenerate.mockResolvedValueOnce({
+      status: 'ok',
+      data: { listing_id: 42, basis: 'known', letter: 'LETTER-BODY' },
+    });
+    render(<HerabsetzungDialog listingId={42} onClose={() => {}} />);
+
+    fillTenantName();
+    fireEvent.click(screen.getByTestId('herabsetzung-submit'));
+
+    await screen.findByTestId('herabsetzung-letter');
+    fireEvent.click(screen.getByTestId('herabsetzung-copy'));
+
+    await waitFor(() => expect(writeText).toHaveBeenCalledWith('LETTER-BODY'));
+  });
+
+  it('calls onClose when the close button is clicked', () => {
+    const onClose = vi.fn();
+    render(<HerabsetzungDialog listingId={42} onClose={onClose} />);
+
+    fireEvent.click(screen.getByTestId('herabsetzung-close'));
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/components/listings/HerabsetzungDialog.tsx
+++ b/apps/web/src/components/listings/HerabsetzungDialog.tsx
@@ -1,0 +1,234 @@
+'use client';
+
+import { useState } from 'react';
+import type { HerabsetzungPayload } from '@/lib/api';
+import { generateHerabsetzung } from '@/lib/api';
+
+interface HerabsetzungDialogProps {
+  listingId: number;
+  onClose: () => void;
+}
+
+const NO_REDUCTION_MESSAGE =
+  'Für dieses Inserat besteht aktuell kein Anspruch auf eine Mietzinssenkung.';
+const GENERIC_ERROR_MESSAGE = 'Das Schreiben konnte nicht erstellt werden. Bitte erneut versuchen.';
+const REQUIRED_NAME_MESSAGE = 'Bitte den Namen der Mieterin / des Mieters angeben.';
+
+function getErrorMessage(error: unknown): string {
+  if (error instanceof Error && error.message) {
+    return error.message;
+  }
+  return GENERIC_ERROR_MESSAGE;
+}
+
+/** Copy text to clipboard with a document.execCommand fallback for older browsers. */
+async function copyToClipboard(text: string): Promise<void> {
+  if (navigator.clipboard?.writeText) {
+    await navigator.clipboard.writeText(text);
+    return;
+  }
+  const textarea = document.createElement('textarea');
+  textarea.value = text;
+  textarea.style.position = 'fixed';
+  textarea.style.opacity = '0';
+  document.body.appendChild(textarea);
+  textarea.select();
+  try {
+    document.execCommand('copy');
+  } finally {
+    document.body.removeChild(textarea);
+  }
+}
+
+function downloadLetter(text: string, listingId: number): void {
+  const blob = new Blob([text], { type: 'text/plain;charset=utf-8' });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement('a');
+  anchor.href = url;
+  anchor.download = `herabsetzungsbegehren-${listingId}.txt`;
+  document.body.appendChild(anchor);
+  anchor.click();
+  document.body.removeChild(anchor);
+  URL.revokeObjectURL(url);
+}
+
+const inputClass =
+  'w-full rounded-md border border-strata-cream/[0.12] bg-strata-slate-800/60 px-2.5 py-1.5 text-xs-11 text-strata-cream placeholder:text-strata-cream/30 focus:border-strata-amber/50 focus:outline-none';
+const labelClass = 'mb-1 block text-2xs text-strata-cream/50';
+
+export function HerabsetzungDialog({ listingId, onClose }: HerabsetzungDialogProps) {
+  const [tenantName, setTenantName] = useState('');
+  const [tenantAddress, setTenantAddress] = useState('');
+  const [landlordName, setLandlordName] = useState('');
+  const [landlordAddress, setLandlordAddress] = useState('');
+  const [letter, setLetter] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [copied, setCopied] = useState(false);
+
+  async function handleSubmit(event: React.FormEvent) {
+    event.preventDefault();
+    if (!tenantName.trim()) {
+      setError(REQUIRED_NAME_MESSAGE);
+      return;
+    }
+    setError(null);
+    setSubmitting(true);
+    const payload: HerabsetzungPayload = {
+      tenant_name: tenantName.trim(),
+      tenant_address: tenantAddress.trim() || undefined,
+      landlord_name: landlordName.trim() || undefined,
+      landlord_address: landlordAddress.trim() || undefined,
+    };
+    try {
+      const result = await generateHerabsetzung(listingId, payload);
+      if (result.status === 'no_reduction') {
+        setError(NO_REDUCTION_MESSAGE);
+      } else {
+        setLetter(result.data.letter);
+      }
+    } catch (err: unknown) {
+      setError(getErrorMessage(err));
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  async function handleCopy() {
+    if (!letter) return;
+    try {
+      await copyToClipboard(letter);
+      setCopied(true);
+    } catch {
+      setError('Kopieren fehlgeschlagen. Bitte den Text manuell markieren.');
+    }
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Herabsetzungsbegehren erstellen"
+      data-testid="herabsetzung-dialog"
+    >
+      <div className="strata-panel w-full max-w-md p-4">
+        <div className="mb-3 flex items-start justify-between">
+          <p className="strata-panel-title">Herabsetzungsbegehren</p>
+          <button
+            onClick={onClose}
+            data-testid="herabsetzung-close"
+            className="-mr-1 -mt-1 rounded-md p-1 text-[15px] leading-none text-strata-cream/35 transition-colors hover:bg-strata-cream/5 hover:text-strata-cream"
+            aria-label="Schliessen"
+          >
+            ×
+          </button>
+        </div>
+
+        {letter === null ? (
+          <form onSubmit={handleSubmit} data-testid="herabsetzung-form">
+            <p className="mb-3 text-2xs leading-relaxed text-strata-cream/45">
+              Erstellt ein formelles Schreiben zur Mietzinssenkung an die Verwaltung.
+            </p>
+
+            <div className="mb-2">
+              <label htmlFor="tenant-name" className={labelClass}>
+                Name Mieter:in *
+              </label>
+              <input
+                id="tenant-name"
+                data-testid="field-tenant-name"
+                className={inputClass}
+                value={tenantName}
+                onChange={(e) => setTenantName(e.target.value)}
+                placeholder="Anna Muster"
+              />
+            </div>
+
+            <div className="mb-2">
+              <label htmlFor="tenant-address" className={labelClass}>
+                Adresse Mieter:in
+              </label>
+              <input
+                id="tenant-address"
+                data-testid="field-tenant-address"
+                className={inputClass}
+                value={tenantAddress}
+                onChange={(e) => setTenantAddress(e.target.value)}
+                placeholder="Langstrasse 1, 8004 Zürich"
+              />
+            </div>
+
+            <div className="mb-2">
+              <label htmlFor="landlord-name" className={labelClass}>
+                Name Verwaltung / Vermieter:in
+              </label>
+              <input
+                id="landlord-name"
+                data-testid="field-landlord-name"
+                className={inputClass}
+                value={landlordName}
+                onChange={(e) => setLandlordName(e.target.value)}
+                placeholder="Immo AG"
+              />
+            </div>
+
+            <div className="mb-3">
+              <label htmlFor="landlord-address" className={labelClass}>
+                Adresse Verwaltung
+              </label>
+              <input
+                id="landlord-address"
+                data-testid="field-landlord-address"
+                className={inputClass}
+                value={landlordAddress}
+                onChange={(e) => setLandlordAddress(e.target.value)}
+                placeholder="Bahnhofstrasse 1, 8001 Zürich"
+              />
+            </div>
+
+            {error && (
+              <p className="mb-2 text-xs-11 text-strata-terracotta" data-testid="herabsetzung-error">
+                {error}
+              </p>
+            )}
+
+            <button
+              type="submit"
+              data-testid="herabsetzung-submit"
+              disabled={submitting}
+              className="w-full rounded-md border border-strata-amber/30 bg-strata-amber/10 px-3 py-1.5 text-xs-11 font-medium text-strata-amber transition-colors hover:bg-strata-amber/20 disabled:opacity-50"
+            >
+              {submitting ? 'Wird erstellt…' : 'Schreiben erstellen'}
+            </button>
+          </form>
+        ) : (
+          <div data-testid="herabsetzung-result">
+            <pre
+              data-testid="herabsetzung-letter"
+              className="strata-scroll strata-data max-h-[320px] overflow-y-auto whitespace-pre-wrap rounded-md border border-strata-cream/[0.08] bg-strata-slate-800/60 p-3 text-2xs leading-relaxed text-strata-cream/90"
+            >
+              {letter}
+            </pre>
+            <div className="mt-3 flex gap-2">
+              <button
+                onClick={handleCopy}
+                data-testid="herabsetzung-copy"
+                className="flex-1 rounded-md border border-strata-cream/[0.12] px-3 py-1.5 text-xs-11 text-strata-cream/80 transition-colors hover:bg-strata-cream/[0.06]"
+              >
+                {copied ? 'Kopiert ✓' : 'Kopieren'}
+              </button>
+              <button
+                onClick={() => downloadLetter(letter, listingId)}
+                data-testid="herabsetzung-download"
+                className="flex-1 rounded-md border border-strata-amber/30 bg-strata-amber/10 px-3 py-1.5 text-xs-11 font-medium text-strata-amber transition-colors hover:bg-strata-amber/20"
+              >
+                Download .txt
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/listings/RentAnalysisBadge.test.tsx
+++ b/apps/web/src/components/listings/RentAnalysisBadge.test.tsx
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { RentAnalysisBadge } from './RentAnalysisBadge';
+import type { RentAnalysis } from '@/lib/api';
+
+vi.mock('@/lib/api', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/api')>();
+  return {
+    ...actual,
+    fetchRentAnalysis: vi.fn(),
+    generateHerabsetzung: vi.fn(),
+  };
+});
+
+import { fetchRentAnalysis } from '@/lib/api';
+
+const mockFetchRentAnalysis = vi.mocked(fetchRentAnalysis);
+
+const REDUCTION: RentAnalysis = {
+  listing_id: 42,
+  basis: 'known',
+  base_rate: 1.75,
+  current_rate: 1.5,
+  rent_net: 2000,
+  change_pct: -2.91,
+  monthly_chf: -114.8,
+  new_rent_net: 1885.2,
+  direction: 'reduction',
+  message: 'Mietsenkung möglich',
+};
+
+beforeEach(() => {
+  mockFetchRentAnalysis.mockReset();
+});
+
+describe('RentAnalysisBadge', () => {
+  it('renders a reduction badge with the formatted monthly saving', async () => {
+    mockFetchRentAnalysis.mockResolvedValueOnce(REDUCTION);
+    render(<RentAnalysisBadge listingId={42} />);
+
+    const badge = await screen.findByTestId('rent-analysis-badge');
+    expect(badge.textContent).toContain('Mietsenkung');
+    expect(badge.textContent).toMatch(/114[.,]80/);
+  });
+
+  it('shows the assumed-basis hint when basis is assumed_from_first_seen', async () => {
+    mockFetchRentAnalysis.mockResolvedValueOnce({ ...REDUCTION, basis: 'assumed_from_first_seen' });
+    render(<RentAnalysisBadge listingId={42} />);
+
+    await screen.findByTestId('rent-analysis-badge');
+    expect(screen.getByTestId('rent-analysis-hint').textContent).toContain('geschätzt');
+  });
+
+  it('does not show the hint when basis is known', async () => {
+    mockFetchRentAnalysis.mockResolvedValueOnce(REDUCTION);
+    render(<RentAnalysisBadge listingId={42} />);
+
+    await screen.findByTestId('rent-analysis-badge');
+    expect(screen.queryByTestId('rent-analysis-hint')).toBeNull();
+  });
+
+  it('renders nothing for basis unknown', async () => {
+    mockFetchRentAnalysis.mockResolvedValueOnce({ ...REDUCTION, basis: 'unknown', direction: null });
+    const { container } = render(<RentAnalysisBadge listingId={42} />);
+
+    await waitFor(() => expect(mockFetchRentAnalysis).toHaveBeenCalled());
+    expect(container.querySelector('[data-testid="rent-analysis-badge"]')).toBeNull();
+  });
+
+  it('renders nothing when direction is increase', async () => {
+    mockFetchRentAnalysis.mockResolvedValueOnce({ ...REDUCTION, direction: 'increase' });
+    const { container } = render(<RentAnalysisBadge listingId={42} />);
+
+    await waitFor(() => expect(mockFetchRentAnalysis).toHaveBeenCalled());
+    expect(container.querySelector('[data-testid="rent-analysis-badge"]')).toBeNull();
+  });
+
+  it('renders nothing when direction is none', async () => {
+    mockFetchRentAnalysis.mockResolvedValueOnce({ ...REDUCTION, direction: 'none' });
+    const { container } = render(<RentAnalysisBadge listingId={42} />);
+
+    await waitFor(() => expect(mockFetchRentAnalysis).toHaveBeenCalled());
+    expect(container.querySelector('[data-testid="rent-analysis-badge"]')).toBeNull();
+  });
+
+  it('renders nothing on fetch error', async () => {
+    mockFetchRentAnalysis.mockRejectedValueOnce(new Error('boom'));
+    const { container } = render(<RentAnalysisBadge listingId={42} />);
+
+    await waitFor(() => expect(mockFetchRentAnalysis).toHaveBeenCalled());
+    expect(container.querySelector('[data-testid="rent-analysis-badge"]')).toBeNull();
+  });
+
+  it('opens the letter dialog when the badge is clicked', async () => {
+    mockFetchRentAnalysis.mockResolvedValueOnce(REDUCTION);
+    render(<RentAnalysisBadge listingId={42} />);
+
+    const badge = await screen.findByTestId('rent-analysis-badge');
+    expect(screen.queryByTestId('herabsetzung-dialog')).toBeNull();
+    fireEvent.click(badge);
+    expect(screen.getByTestId('herabsetzung-dialog')).toBeTruthy();
+  });
+});

--- a/apps/web/src/components/listings/RentAnalysisBadge.tsx
+++ b/apps/web/src/components/listings/RentAnalysisBadge.tsx
@@ -1,0 +1,71 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import type { RentAnalysis } from '@/lib/api';
+import { fetchRentAnalysis } from '@/lib/api';
+import { HerabsetzungDialog } from './HerabsetzungDialog';
+
+interface RentAnalysisBadgeProps {
+  listingId: number;
+}
+
+function formatChf(amount: number): string {
+  return Math.abs(amount).toLocaleString('de-CH', {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  });
+}
+
+export function RentAnalysisBadge({ listingId }: RentAnalysisBadgeProps) {
+  const [analysis, setAnalysis] = useState<RentAnalysis | null>(null);
+  const [dialogOpen, setDialogOpen] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetchRentAnalysis(listingId)
+      .then((result) => {
+        if (!cancelled) setAnalysis(result);
+      })
+      .catch(() => {
+        // A missing analysis is not an error worth surfacing — render nothing.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [listingId]);
+
+  if (
+    analysis === null ||
+    analysis.basis === 'unknown' ||
+    analysis.direction !== 'reduction' ||
+    analysis.monthly_chf === null
+  ) {
+    return null;
+  }
+
+  const assumed = analysis.basis === 'assumed_from_first_seen';
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setDialogOpen(true)}
+        data-testid="rent-analysis-badge"
+        className="mt-2 flex w-full flex-col items-start gap-0.5 rounded-md border border-strata-terracotta/30 bg-strata-terracotta/10 px-2.5 py-1.5 text-left transition-colors hover:bg-strata-terracotta/20"
+      >
+        <span className="strata-data text-xs-11 font-medium text-strata-terracotta">
+          Mietsenkung möglich: CHF {formatChf(analysis.monthly_chf)}/Mt.
+        </span>
+        {assumed && (
+          <span className="text-2xs text-strata-terracotta/70" data-testid="rent-analysis-hint">
+            geschätzt aus Inseratsdatum
+          </span>
+        )}
+      </button>
+
+      {dialogOpen && (
+        <HerabsetzungDialog listingId={listingId} onClose={() => setDialogOpen(false)} />
+      )}
+    </>
+  );
+}

--- a/apps/web/src/components/map/ListingCards.test.tsx
+++ b/apps/web/src/components/map/ListingCards.test.tsx
@@ -1,7 +1,40 @@
-import { describe, it, expect } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import type { ListingSummary, RentAnalysis } from '@/lib/api';
+
+vi.mock('@/lib/api', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/api')>();
+  return {
+    ...actual,
+    fetchRentAnalysis: vi.fn(),
+    generateHerabsetzung: vi.fn(),
+  };
+});
+
 import { ListingCards } from './ListingCards';
-import type { ListingSummary } from '@/lib/api';
+import { fetchRentAnalysis } from '@/lib/api';
+
+const mockFetchRentAnalysis = vi.mocked(fetchRentAnalysis);
+
+const REDUCTION: RentAnalysis = {
+  listing_id: 1,
+  basis: 'known',
+  base_rate: 1.75,
+  current_rate: 1.5,
+  rent_net: 2000,
+  change_pct: -2.91,
+  monthly_chf: -114.8,
+  new_rent_net: 1885.2,
+  direction: 'reduction',
+  message: 'Mietsenkung möglich',
+};
+
+beforeEach(() => {
+  // Default: no reduction applies, so the badge renders nothing and existing
+  // assertions are unaffected.
+  mockFetchRentAnalysis.mockReset();
+  mockFetchRentAnalysis.mockResolvedValue({ ...REDUCTION, basis: 'unknown', direction: null });
+});
 
 const listing: ListingSummary = {
   id: 1,
@@ -149,6 +182,18 @@ describe('ListingCards', () => {
     render(<ListingCards listings={[listing]} />);
     expect(screen.getByTestId('listing-rent-period')).toBeTruthy();
     expect(screen.getByTestId('listing-rent-period').textContent).toContain('/mt.');
+  });
+
+  it('renders a RentAnalysisBadge per listing when a reduction applies', async () => {
+    mockFetchRentAnalysis.mockResolvedValue(REDUCTION);
+    const listings = [listing, { ...listing, id: 2, source_id: 'L-1002' }];
+    render(<ListingCards listings={listings} />);
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId('rent-analysis-badge').length).toBe(2);
+    });
+    expect(mockFetchRentAnalysis).toHaveBeenCalledWith(1);
+    expect(mockFetchRentAnalysis).toHaveBeenCalledWith(2);
   });
 
   it('image thumbnails have object-cover class', () => {

--- a/apps/web/src/components/map/ListingCards.tsx
+++ b/apps/web/src/components/map/ListingCards.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 import type { ListingSummary } from '@/lib/api';
 import { mediaUrl } from '@/lib/api';
+import { RentAnalysisBadge } from '@/components/listings/RentAnalysisBadge';
 
 interface Props {
   listings: ListingSummary[];
@@ -204,6 +205,8 @@ export function ListingCards({ listings }: Props) {
               </div>
 
               {l.description && <TruncatedDescription text={l.description} />}
+
+              <RentAnalysisBadge listingId={l.id} />
 
               <div className="mt-2.5 flex items-center justify-between">
                 <div className="flex items-center gap-3">

--- a/apps/web/src/components/map/QuartierProfile.commute.test.tsx
+++ b/apps/web/src/components/map/QuartierProfile.commute.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { render } from '@testing-library/react';
+import type { QuartierProfile as QuartierProfileData } from '@/lib/api';
 
 const baseProfile = {
   quartier_id: 1,
@@ -55,8 +56,8 @@ describe('QuartierProfile commute_hb_min display', () => {
 
   it('does NOT show commute row when commute_hb_min is undefined', async () => {
     const { QuartierProfile } = await import('./QuartierProfile');
-    // Cast to allow undefined for legacy data compatibility test
-    const profile = { ...baseProfile } as typeof baseProfile & { commute_hb_min?: number | null };
+    // Legacy data compatibility: commute_hb_min may be entirely absent.
+    const profile = { ...baseProfile } as unknown as QuartierProfileData;
     const { queryByTestId } = render(
       <QuartierProfile
         profile={profile}

--- a/apps/web/src/lib/__tests__/api-commute.test.ts
+++ b/apps/web/src/lib/__tests__/api-commute.test.ts
@@ -66,8 +66,9 @@ describe('fetchCommuteIsochrone', () => {
     });
 
     const result = await fetchCommuteIsochrone('hb');
-    expect(result.type).toBe('FeatureCollection');
-    expect(Array.isArray(result.features)).toBe(true);
+    expect(result).not.toBeNull();
+    expect(result?.type).toBe('FeatureCollection');
+    expect(Array.isArray(result?.features)).toBe(true);
   });
 
   it('returns null on 404 response', async () => {

--- a/apps/web/src/lib/api-legal.test.ts
+++ b/apps/web/src/lib/api-legal.test.ts
@@ -1,0 +1,188 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock fetch globally
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+beforeEach(() => {
+  vi.resetModules();
+  mockFetch.mockReset();
+});
+
+const REDUCTION = {
+  listing_id: 42,
+  basis: 'known',
+  base_rate: 1.75,
+  current_rate: 1.5,
+  rent_net: 2000,
+  change_pct: -2.91,
+  monthly_chf: -114.8,
+  new_rent_net: 1885.2,
+  direction: 'reduction',
+  message: 'Mietsenkung möglich',
+};
+
+describe('fetchRentAnalysis', () => {
+  it('fetches from the correct URL', async () => {
+    process.env.NEXT_PUBLIC_API_URL = 'http://localhost:8000';
+    const { fetchRentAnalysis } = await import('./api');
+
+    mockFetch.mockResolvedValueOnce({ ok: true, json: async () => REDUCTION });
+
+    await fetchRentAnalysis(42);
+    expect(mockFetch).toHaveBeenCalledWith('http://localhost:8000/legal/listings/42/rent-analysis');
+  });
+
+  it('appends base_rate query param when provided', async () => {
+    process.env.NEXT_PUBLIC_API_URL = 'http://localhost:8000';
+    const { fetchRentAnalysis } = await import('./api');
+
+    mockFetch.mockResolvedValueOnce({ ok: true, json: async () => REDUCTION });
+
+    await fetchRentAnalysis(42, 1.75);
+    expect(mockFetch).toHaveBeenCalledWith(
+      'http://localhost:8000/legal/listings/42/rent-analysis?base_rate=1.75'
+    );
+  });
+
+  it('returns parsed analysis on success', async () => {
+    process.env.NEXT_PUBLIC_API_URL = '';
+    const { fetchRentAnalysis } = await import('./api');
+
+    mockFetch.mockResolvedValueOnce({ ok: true, json: async () => REDUCTION });
+
+    const result = await fetchRentAnalysis(42);
+    expect(result).toEqual(REDUCTION);
+  });
+
+  it('uses empty string base URL when env var is not set', async () => {
+    delete process.env.NEXT_PUBLIC_API_URL;
+    const { fetchRentAnalysis } = await import('./api');
+
+    mockFetch.mockResolvedValueOnce({ ok: true, json: async () => REDUCTION });
+
+    await fetchRentAnalysis(42);
+    expect(mockFetch).toHaveBeenCalledWith('/legal/listings/42/rent-analysis');
+  });
+
+  it('throws on non-ok response', async () => {
+    process.env.NEXT_PUBLIC_API_URL = '';
+    const { fetchRentAnalysis } = await import('./api');
+
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 500 });
+
+    await expect(fetchRentAnalysis(42)).rejects.toThrow('500');
+  });
+
+  it('throws on malformed response shape', async () => {
+    process.env.NEXT_PUBLIC_API_URL = '';
+    const { fetchRentAnalysis } = await import('./api');
+
+    mockFetch.mockResolvedValueOnce({ ok: true, json: async () => ({ bad: 'data' }) });
+
+    await expect(fetchRentAnalysis(42)).rejects.toThrow('Unexpected response shape');
+  });
+
+  it('propagates network errors', async () => {
+    process.env.NEXT_PUBLIC_API_URL = '';
+    const { fetchRentAnalysis } = await import('./api');
+
+    mockFetch.mockRejectedValueOnce(new Error('network down'));
+
+    await expect(fetchRentAnalysis(42)).rejects.toThrow('network down');
+  });
+});
+
+describe('generateHerabsetzung', () => {
+  const payload = {
+    tenant_name: 'Anna Muster',
+    tenant_address: 'Langstrasse 1, 8004 Zürich',
+    landlord_name: 'Immo AG',
+    landlord_address: 'Bahnhofstrasse 1, 8001 Zürich',
+  };
+
+  it('POSTs to the correct URL with JSON body', async () => {
+    process.env.NEXT_PUBLIC_API_URL = 'http://localhost:8000';
+    const { generateHerabsetzung } = await import('./api');
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({ listing_id: 42, basis: 'known', letter: 'Sehr geehrte Damen…' }),
+    });
+
+    await generateHerabsetzung(42, payload);
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      'http://localhost:8000/legal/listings/42/herabsetzungsbegehren',
+      expect.objectContaining({
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      })
+    );
+  });
+
+  it('returns ok result with the letter on success', async () => {
+    process.env.NEXT_PUBLIC_API_URL = '';
+    const { generateHerabsetzung } = await import('./api');
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({ listing_id: 42, basis: 'known', letter: 'BODY' }),
+    });
+
+    const result = await generateHerabsetzung(42, payload);
+    expect(result.status).toBe('ok');
+    if (result.status === 'ok') {
+      expect(result.data.letter).toBe('BODY');
+      expect(result.data.listing_id).toBe(42);
+    }
+  });
+
+  it('returns a distinguishable no_reduction result on 409', async () => {
+    process.env.NEXT_PUBLIC_API_URL = '';
+    const { generateHerabsetzung } = await import('./api');
+
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 409,
+      json: async () => ({ detail: 'no reduction applies' }),
+    });
+
+    const result = await generateHerabsetzung(42, payload);
+    expect(result.status).toBe('no_reduction');
+  });
+
+  it('throws with the detail message on 422 validation error', async () => {
+    process.env.NEXT_PUBLIC_API_URL = '';
+    const { generateHerabsetzung } = await import('./api');
+
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 422,
+      json: async () => ({ detail: 'tenant_name is required' }),
+    });
+
+    await expect(generateHerabsetzung(42, payload)).rejects.toThrow('tenant_name is required');
+  });
+
+  it('throws on other non-ok responses', async () => {
+    process.env.NEXT_PUBLIC_API_URL = '';
+    const { generateHerabsetzung } = await import('./api');
+
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 500, json: async () => ({}) });
+
+    await expect(generateHerabsetzung(42, payload)).rejects.toThrow('500');
+  });
+
+  it('propagates network errors', async () => {
+    process.env.NEXT_PUBLIC_API_URL = '';
+    const { generateHerabsetzung } = await import('./api');
+
+    mockFetch.mockRejectedValueOnce(new Error('offline'));
+
+    await expect(generateHerabsetzung(42, payload)).rejects.toThrow('offline');
+  });
+});

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -289,3 +289,95 @@ export async function fetchWatchEvents(token: string, days = 90): Promise<{ tota
   }
   return data as { total: number; items: WatchEvent[] };
 }
+
+// ── Legal intelligence (Referenzzinssatz / Herabsetzungsbegehren) ───────────────
+
+export type RentAnalysisBasis = 'known' | 'assumed_from_first_seen' | 'override' | 'unknown';
+export type RentAnalysisDirection = 'reduction' | 'increase' | 'none' | null;
+
+export interface RentAnalysis {
+  listing_id: number;
+  basis: RentAnalysisBasis;
+  base_rate: number | null;
+  current_rate: number | null;
+  rent_net: number | null;
+  change_pct: number | null;
+  monthly_chf: number | null;
+  new_rent_net: number | null;
+  direction: RentAnalysisDirection;
+  message: string;
+}
+
+/** Fetch the rent-vs-reference-rate analysis for a listing. */
+export async function fetchRentAnalysis(listingId: number, baseRate?: number): Promise<RentAnalysis> {
+  const query = baseRate != null ? `?base_rate=${baseRate}` : '';
+  const res = await fetch(`${BASE_URL}/legal/listings/${listingId}/rent-analysis${query}`);
+  if (!res.ok) {
+    throw new Error(`${res.status}`);
+  }
+  const data: unknown = await res.json();
+  if (
+    typeof data !== 'object' ||
+    data === null ||
+    typeof (data as Record<string, unknown>).listing_id !== 'number'
+  ) {
+    throw new Error('Unexpected response shape: missing listing_id');
+  }
+  return data as RentAnalysis;
+}
+
+export interface HerabsetzungPayload {
+  tenant_name: string;
+  tenant_address?: string;
+  landlord_name?: string;
+  landlord_address?: string;
+  property_address?: string;
+  base_rate?: number;
+  actual_rent?: number;
+}
+
+export interface HerabsetzungLetter {
+  listing_id: number;
+  basis: RentAnalysisBasis;
+  letter: string;
+}
+
+/**
+ * Result of a Herabsetzungsbegehren request. A 409 (no reduction applies) is
+ * surfaced as a distinguishable result rather than a thrown error so the UI can
+ * show a friendly message. Validation (422) and other failures throw.
+ */
+export type HerabsetzungResult =
+  | { status: 'ok'; data: HerabsetzungLetter }
+  | { status: 'no_reduction' };
+
+export async function generateHerabsetzung(
+  listingId: number,
+  payload: HerabsetzungPayload,
+): Promise<HerabsetzungResult> {
+  const res = await fetch(`${BASE_URL}/legal/listings/${listingId}/herabsetzungsbegehren`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+
+  if (res.status === 409) {
+    return { status: 'no_reduction' };
+  }
+  if (!res.ok) {
+    let message = `${res.status}`;
+    try {
+      const body: unknown = await res.json();
+      const detail = (body as Record<string, unknown> | null)?.detail;
+      if (typeof detail === 'string' && detail.length > 0) {
+        message = detail;
+      }
+    } catch {
+      // Response had no JSON body — fall back to the status code.
+    }
+    throw new Error(message);
+  }
+
+  const data = (await res.json()) as HerabsetzungLetter;
+  return { status: 'ok', data };
+}


### PR DESCRIPTION
Completes #17 end-to-end — the merged `/legal` backend now has a user-facing surface (autonomous dev loop, iteration 3A; built TDD by an Opus 4.8 agent, reviewed by the orchestrator).

## What
- **RentAnalysisBadge** on every listing card: "Mietsenkung möglich: CHF 114.80/Mt." (terracotta accent) when the Referenzzinssatz analysis shows a reduction entitlement. Hidden for unknown basis, increases, no-change, loading, or errors — zero noise. Assumed basis shows "geschätzt aus Inseratsdatum".
- **HerabsetzungDialog**: one tap → tenant/landlord form → generated German letter in a monospace view with **Copy** and **Download .txt**. 409 (no reduction applies) gets a friendly German message.
- **api.ts wrappers**: `fetchRentAnalysis`, `generateHerabsetzung` — 409 as a discriminated `no_reduction` result, 422 server detail propagated, response-shape validation.
- **Chore**: fixed the 3 pre-existing tsc errors in commute test files — `npx tsc --noEmit` is now fully clean repo-wide.

## Testing
- +28 tests → **314 total, all green**; zero regressions
- `npm run lint` 0 errors; `npx tsc --noEmit` **0 errors**

## Test plan
- [ ] With the API running locally, open a building with listings — badge appears for listings with a reduction entitlement
- [ ] Generate a letter, copy + download it
- [ ] Letter content matches the backend template (citations, amounts)