### PR TITLE
feat: initial rent challenge analysis via Quartierüblichkeit (OR Art. 270)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -27,7 +27,7 @@ Update this file when phases shift. Claude Code reads it every session via CLAUD
 | Photos stored | 565+ |
 | Quartiere with profiles | 34 |
 | Noise data points | 1,071,340 |
-| Backend tests | 703 |
+| Backend tests | 727 |
 | Frontend tests | 344 |
 
 ---
@@ -176,7 +176,7 @@ The layer that answers "where should I live?" Four dimensions.
 |-----------|--------|-------|
 | Referenzzinssatz auto-tracking | 🟢 Done — history table + `/legal/reference-rate`, per-listing analysis (OR 269a step table), badge in listing cards | #17 |
 | Pre-drafted Herabsetzungsbegehren | 🟢 Done — API + one-tap letter dialog (copy/download) in listing cards | #17 |
-| Initial rent challenge analysis (OR Art. 270) | ⚪ Planned | #TBD |
+| Initial rent challenge analysis (OR Art. 270) | 🟢 Backend done — Quartierüblichkeit comparables, `GET /legal/listings/{id}/initial-rent-check` | — |
 | Rent increase verification | ⚪ Planned | #TBD |
 | Mängelrüge templates | 💡 Idea | #TBD |
 | Kündigungstermin reminders | 💡 Idea | #TBD |

--- a/apps/api/src/strata_api/legal/or270.py
+++ b/apps/api/src/strata_api/legal/or270.py
@@ -1,0 +1,76 @@
+"""OR Art. 270 — static legal-information payload for the initial-rent challenge.
+
+Keeps the reviewed legal copy in one place. A tenant may contest the INITIAL
+rent before the Schlichtungsbehörde within 30 days of taking over the flat if
+one of the statutory conditions is met (personal/family hardship, a local
+housing shortage — in Zurich the shortage is regularly acknowledged — or a
+significant increase versus the previous tenancy). The assessment uses the
+"absolute method" via Quartierüblichkeit (OR Art. 269a lit. a).
+
+German legal terms are paired with English explanations, matching
+``legal/herabsetzung.py``. Nothing here is legal advice.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class OR270Info:
+    """Reviewed, static legal-information payload about OR Art. 270."""
+
+    article: str
+    deadline_days: int
+    deadline_note: str
+    conditions: tuple[str, ...]
+    assessment_method: str
+    schlichtungsbehoerde: str
+    disclaimer: str
+
+    def as_dict(self) -> dict:
+        """Serialise for the API response (tuples become lists)."""
+        return {
+            "article": self.article,
+            "deadline_days": self.deadline_days,
+            "deadline_note": self.deadline_note,
+            "conditions": list(self.conditions),
+            "assessment_method": self.assessment_method,
+            "schlichtungsbehoerde": self.schlichtungsbehoerde,
+            "disclaimer": self.disclaimer,
+        }
+
+
+_INFO = OR270Info(
+    article="OR Art. 270 (Anfechtung des Anfangsmietzinses)",
+    deadline_days=30,
+    deadline_note=(
+        "Frist: 30 Tage / within 30 days of taking over the flat (Übernahme der Wohnung) "
+        "you may contest the initial rent before the Schlichtungsbehörde."
+    ),
+    conditions=(
+        "Persönliche oder familiäre Notlage / personal or family hardship compelling you "
+        "to accept the contract.",
+        "Wohnungsmangel / local housing shortage — in Zurich this condition is regularly "
+        "acknowledged as satisfied.",
+        "Erhebliche Erhöhung / the rent was significantly increased versus the previous "
+        "tenancy's rent.",
+    ),
+    assessment_method=(
+        "Absolute Methode via Quartierüblichkeit / the absolute method: comparison with "
+        "rents customary in the quarter for comparable objects (OR Art. 269a lit. a)."
+    ),
+    schlichtungsbehoerde=(
+        "Schlichtungsbehörde in Mietsachen / the free tenancy mediation authority for your "
+        "district is the body that hears an initial-rent challenge (Mietschlichtungsbehörde "
+        "des Bezirks)."
+    ),
+    disclaimer=(
+        "Hinweis: Dies ist eine indikative Analyse und keine Rechtsberatung. / This is an "
+        "indicative analysis, not legal advice. Verify the facts and deadlines for your case."
+    ),
+)
+
+
+def or270_info() -> OR270Info:
+    """Return the reviewed static OR Art. 270 information payload."""
+    return _INFO

--- a/apps/api/src/strata_api/legal/quartierueblichkeit.py
+++ b/apps/api/src/strata_api/legal/quartierueblichkeit.py
@@ -1,0 +1,257 @@
+"""Quartierüblichkeit — comparables math for initial-rent (OR Art. 270) analysis.
+
+The "absolute method" of contesting an initial rent relies on *Quartierüblichkeit*:
+comparing the rent of a flat with rents customary in the same quarter for
+comparable objects (OR Art. 269a lit. a). A proper legal comparison needs at
+least five genuinely comparable objects with documented characteristics.
+
+Strata cannot produce a court-grade comparison. Instead it *approximates*
+Quartierüblichkeit from its own listings corpus (asking rents, not concluded
+rents) to give tenants an INDICATIVE signal of whether an asking rent looks
+elevated versus the neighbourhood. Every result therefore carries an explicit
+"not legal advice" framing, mirroring ``legal/herabsetzung.py``.
+
+This module is pure math: it never touches the database. The router feeds it a
+target listing and a candidate pool; selection + statistics happen here.
+"""
+from __future__ import annotations
+
+import datetime
+import statistics
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Protocol
+
+
+class ListingLike(Protocol):
+    """Structural type for the listing fields this module reads.
+
+    Both the SQLAlchemy ``Listing`` ORM object and lightweight test doubles
+    satisfy it — the module never imports the DB model.
+    """
+
+    id: int
+    rooms: float | None
+    area_m2: float | None
+    rent_net: float | None
+    plz: int | None
+    last_seen: datetime.datetime
+
+
+# --- Comparison criteria (documented constants) ------------------------------
+# Rooms within ±0.5 of the target: half-room granularity is how Swiss flats are
+# advertised, so 3.5 rooms is comparable to 3.0/4.0 but not to 2.5/4.5.
+ROOMS_TOLERANCE = 0.5
+# Area within ±20% of the target: broad enough to gather a usable sample, tight
+# enough that CHF/m² stays meaningful.
+AREA_TOLERANCE_PCT = 0.20
+# Only listings seen within the last 24 months count — older asking rents are a
+# poor proxy for the current market.
+RECENCY_MONTHS = 24
+# Fewer than 5 comparables is not a defensible basis for any statement about the
+# quarter, so the verdict is withheld (mirrors the legal 5-object minimum).
+MIN_COMPARABLES = 5
+# A target is only flagged "clearly above market" once it exceeds the 75th
+# percentile by more than 10%. The margin is deliberately conservative: it
+# favours false negatives (staying silent) over false positives (wrongly
+# implying a contestable rent), because this is an indicative, not legal, tool.
+CLEARLY_ABOVE_FACTOR = 1.10
+
+
+@dataclass(frozen=True)
+class ComparableCriteria:
+    """Filters defining which listings count as comparable to a target."""
+
+    rooms_tolerance: float = ROOMS_TOLERANCE
+    area_tolerance_pct: float = AREA_TOLERANCE_PCT
+    recency_months: int = RECENCY_MONTHS
+
+
+DEFAULT_CRITERIA = ComparableCriteria()
+
+
+class Verdict(StrEnum):
+    """Indicative classification of a target's asking rent vs. the quarter."""
+
+    INSUFFICIENT_DATA = "insufficient_data"
+    WITHIN_RANGE = "within_range"
+    ABOVE_MARKET = "above_market"
+    CLEARLY_ABOVE_MARKET = "clearly_above_market"
+
+
+@dataclass(frozen=True)
+class InitialRentAnalysis:
+    """Result of an indicative Quartierüblichkeit comparison."""
+
+    verdict: Verdict
+    target_chf_m2: float | None
+    median_chf_m2: float | None
+    p25_chf_m2: float | None
+    p75_chf_m2: float | None
+    comparable_count: int
+    explanation: str
+
+
+def _subtract_months(moment: datetime.datetime, months: int) -> datetime.datetime:
+    """Return ``moment`` shifted back by ``months`` calendar months (day-clamped)."""
+    total = (moment.year * 12 + (moment.month - 1)) - months
+    year, month = divmod(total, 12)
+    month += 1
+    # Clamp the day so e.g. shifting from the 31st into a shorter month is valid.
+    day = min(moment.day, [31, 29 if year % 4 == 0 and (year % 100 != 0 or year % 400 == 0) else 28,
+                           31, 30, 31, 30, 31, 31, 30, 31, 30, 31][month - 1])
+    return moment.replace(year=year, month=month, day=day)
+
+
+def _chf_per_m2(listing: ListingLike) -> float | None:
+    """CHF/m² of net rent for a listing, or None if rent or area is missing/invalid."""
+    if listing.rent_net is None or listing.area_m2 is None or listing.area_m2 <= 0:
+        return None
+    return round(listing.rent_net / listing.area_m2, 2)
+
+
+def _nearest_rank_percentile(sorted_values: list[float], pct: float) -> float:
+    """Nearest-rank percentile of an already-sorted, non-empty list.
+
+    rank = ceil(pct/100 * N), clamped to [1, N]; returns the rank-th value.
+    Simple and exactly reproducible — the tests pin the expected outputs.
+    """
+    n = len(sorted_values)
+    rank = -(-int(pct) * n // 100)  # ceil(pct * n / 100) via floor-division trick
+    rank = max(1, min(rank, n))
+    return sorted_values[rank - 1]
+
+
+def select_comparables(
+    target: ListingLike,
+    candidates: list[ListingLike],
+    *,
+    criteria: ComparableCriteria = DEFAULT_CRITERIA,
+    now: datetime.datetime | None = None,
+) -> list[ListingLike]:
+    """Filter ``candidates`` down to those comparable to ``target``.
+
+    Excludes: the target itself (by id), listings missing rent_net or area_m2,
+    a different PLZ, rooms outside ±tolerance, area outside ±tolerance, and
+    listings last seen before the recency window. If the target lacks an area
+    (or rooms, when comparing) the result is empty — comparability is undefined.
+    """
+    if target.area_m2 is None or target.area_m2 <= 0:
+        return []
+    now = now or datetime.datetime.utcnow()
+    cutoff = _subtract_months(now, criteria.recency_months)
+    area_lo = target.area_m2 * (1 - criteria.area_tolerance_pct)
+    area_hi = target.area_m2 * (1 + criteria.area_tolerance_pct)
+
+    selected: list[ListingLike] = []
+    for c in candidates:
+        if c.id == target.id:
+            continue
+        if c.rent_net is None or c.area_m2 is None or c.area_m2 <= 0:
+            continue
+        if c.plz != target.plz:
+            continue
+        if target.rooms is not None and (
+            c.rooms is None or abs(c.rooms - target.rooms) > criteria.rooms_tolerance
+        ):
+            continue
+        if not (area_lo <= c.area_m2 <= area_hi):
+            continue
+        if c.last_seen < cutoff:
+            continue
+        selected.append(c)
+    return selected
+
+
+def _classify(target_chf_m2: float, p75: float, count: int) -> Verdict:
+    if count < MIN_COMPARABLES:
+        return Verdict.INSUFFICIENT_DATA
+    if target_chf_m2 <= p75:
+        return Verdict.WITHIN_RANGE
+    if target_chf_m2 <= p75 * CLEARLY_ABOVE_FACTOR:
+        return Verdict.ABOVE_MARKET
+    return Verdict.CLEARLY_ABOVE_MARKET
+
+
+_DISCLAIMER = (
+    "This is an indicative comparison against Strata's listing corpus (asking rents), "
+    "not a Quartierüblichkeit expert report and not legal advice."
+)
+
+
+def analyze_initial_rent(
+    target: ListingLike,
+    comparables: list[ListingLike],
+) -> InitialRentAnalysis:
+    """Compute an indicative initial-rent verdict for ``target`` vs. ``comparables``.
+
+    ``comparables`` should already be filtered via :func:`select_comparables`.
+    """
+    target_chf_m2 = _chf_per_m2(target)
+    values = sorted(v for v in (_chf_per_m2(c) for c in comparables) if v is not None)
+    count = len(values)
+
+    if target_chf_m2 is None:
+        return InitialRentAnalysis(
+            verdict=Verdict.INSUFFICIENT_DATA,
+            target_chf_m2=None,
+            median_chf_m2=None,
+            p25_chf_m2=None,
+            p75_chf_m2=None,
+            comparable_count=count,
+            explanation=(
+                "This listing has no net rent and/or living area on record, so its "
+                f"CHF/m² cannot be computed. No indicative comparison is possible. {_DISCLAIMER}"
+            ),
+        )
+
+    if count < MIN_COMPARABLES:
+        return InitialRentAnalysis(
+            verdict=Verdict.INSUFFICIENT_DATA,
+            target_chf_m2=target_chf_m2,
+            median_chf_m2=None,
+            p25_chf_m2=None,
+            p75_chf_m2=None,
+            comparable_count=count,
+            explanation=(
+                f"Only {count} comparable listing(s) found in this quarter "
+                f"(minimum {MIN_COMPARABLES} required). Asking rent is CHF {target_chf_m2:.1f}/m², "
+                f"but there is not enough local data for an indicative verdict. {_DISCLAIMER}"
+            ),
+        )
+
+    median = round(statistics.median(values), 2)
+    p25 = _nearest_rank_percentile(values, 25)
+    p75 = _nearest_rank_percentile(values, 75)
+    verdict = _classify(target_chf_m2, p75, count)
+
+    explanation = (
+        f"Asking CHF {target_chf_m2:.1f}/m² vs. quartier median CHF {median:.1f}/m² "
+        f"(p25 CHF {p25:.1f}, p75 CHF {p75:.1f}) across {count} comparable listings. "
+        f"{_verdict_sentence(verdict, target_chf_m2, p75)} {_DISCLAIMER}"
+    )
+    return InitialRentAnalysis(
+        verdict=verdict,
+        target_chf_m2=target_chf_m2,
+        median_chf_m2=median,
+        p25_chf_m2=p25,
+        p75_chf_m2=p75,
+        comparable_count=count,
+        explanation=explanation,
+    )
+
+
+def _verdict_sentence(verdict: Verdict, target_chf_m2: float, p75: float) -> str:
+    if verdict is Verdict.WITHIN_RANGE:
+        return "The asking rent sits within the customary range for the quarter (at or below the 75th percentile)."
+    if verdict is Verdict.ABOVE_MARKET:
+        return (
+            f"The asking rent is above the 75th percentile (CHF {p75:.1f}/m²) but within 10% of it — "
+            "somewhat elevated, worth a closer look."
+        )
+    if verdict is Verdict.CLEARLY_ABOVE_MARKET:
+        return (
+            f"The asking rent exceeds the 75th percentile (CHF {p75:.1f}/m²) by more than 10% — "
+            "clearly elevated versus the neighbourhood; an initial-rent challenge may be worth exploring."
+        )
+    return "There is not enough local data for an indicative verdict."

--- a/apps/api/src/strata_api/routers/referenzzins.py
+++ b/apps/api/src/strata_api/routers/referenzzins.py
@@ -19,6 +19,13 @@ from strata_api.db.models.reference_rate import ReferenceRate
 from strata_api.db.session import get_engine
 from strata_api.legal import rates
 from strata_api.legal.herabsetzung import HerabsetzungContext, render
+from strata_api.legal.or270 import or270_info
+from strata_api.legal.quartierueblichkeit import (
+    RECENCY_MONTHS,
+    InitialRentAnalysis,
+    analyze_initial_rent,
+    select_comparables,
+)
 from strata_api.legal.referenzzins import analyze_rent, permitted_change_pct
 
 router = APIRouter(prefix="/legal", tags=["legal"])
@@ -170,6 +177,58 @@ def generate_letter(listing_id: int, req: LetterRequest) -> dict:
         )
         letter = render(context)
     return {"listing_id": listing_id, "basis": basis, "letter": letter}
+
+
+def _comparable_candidates(s: Session, listing: Listing, now: datetime.datetime) -> list[Listing]:
+    """Thin candidate query: same PLZ, seen within the recency window, and active or recent.
+
+    The comparability math (rooms/area/CHF-m² filtering) lives in ``legal/quartierueblichkeit``;
+    this only narrows the DB scan by PLZ and recency to keep the pool small.
+    """
+    if listing.plz is None:
+        return []
+    cutoff = now - datetime.timedelta(days=RECENCY_MONTHS * 31)
+    rows = s.execute(
+        select(Listing).where(
+            Listing.plz == listing.plz,
+            Listing.id != listing.id,
+            Listing.last_seen >= cutoff,
+            (Listing.is_active.is_(True)) | (Listing.last_seen >= cutoff),
+        )
+    ).scalars().all()
+    return list(rows)
+
+
+def _serialize_initial_rent(listing: Listing, analysis: InitialRentAnalysis) -> dict:
+    return {
+        "listing_id": listing.id,
+        "verdict": analysis.verdict.value,
+        "target_chf_m2": analysis.target_chf_m2,
+        "median_chf_m2": analysis.median_chf_m2,
+        "p25": analysis.p25_chf_m2,
+        "p75": analysis.p75_chf_m2,
+        "comparable_count": analysis.comparable_count,
+        "explanation": analysis.explanation,
+        "or270": or270_info().as_dict(),
+    }
+
+
+@router.get("/listings/{listing_id}/initial-rent-check")
+def initial_rent_check(listing_id: int) -> dict:
+    """Indicative OR Art. 270 initial-rent check for a listing vs. the quarter.
+
+    404 for an unknown id. Listings missing rent_net or area_m2 return 200 with a
+    verdict of "insufficient_data" (never 500) — the comparison is simply not possible.
+    """
+    now = datetime.datetime.utcnow()
+    with Session(get_engine()) as s:
+        listing = s.get(Listing, listing_id)
+        if listing is None:
+            raise HTTPException(status_code=404, detail="listing not found")
+        candidates = _comparable_candidates(s, listing, now)
+        comparables = select_comparables(listing, candidates, now=now)
+        analysis = analyze_initial_rent(listing, comparables)
+        return _serialize_initial_rent(listing, analysis)
 
 
 def _listing_address(listing: Listing) -> str:

--- a/apps/api/tests/legal/test_or270.py
+++ b/apps/api/tests/legal/test_or270.py
@@ -1,0 +1,42 @@
+"""Tests for the static OR Art. 270 legal-information payload."""
+from strata_api.legal.or270 import OR270Info, or270_info
+
+
+def test_or270_info_is_frozen_dataclass():
+    info = or270_info()
+    assert isinstance(info, OR270Info)
+
+
+def test_or270_deadline_is_thirty_days():
+    info = or270_info()
+    assert info.deadline_days == 30
+    assert "30 Tage" in info.deadline_note
+
+
+def test_or270_mentions_schlichtungsbehoerde():
+    info = or270_info()
+    blob = " ".join([info.deadline_note, info.schlichtungsbehoerde])
+    assert "Schlichtungsbehörde" in blob
+
+
+def test_or270_conditions_cover_hardship_shortage_increase():
+    joined = " ".join(or270_info().conditions).lower()
+    assert "hardship" in joined
+    assert "shortage" in joined
+    assert "increased" in joined or "increase" in joined
+
+
+def test_or270_assessment_method_is_quartierueblichkeit():
+    assert "Quartierüblichkeit" in or270_info().assessment_method
+
+
+def test_or270_carries_not_legal_advice_disclaimer():
+    disclaimer = or270_info().disclaimer
+    assert "keine Rechtsberatung" in disclaimer
+    assert "not legal advice" in disclaimer
+
+
+def test_or270_as_dict_serialises_conditions_as_list():
+    d = or270_info().as_dict()
+    assert isinstance(d["conditions"], list)
+    assert d["deadline_days"] == 30

--- a/apps/api/tests/legal/test_quartierueblichkeit.py
+++ b/apps/api/tests/legal/test_quartierueblichkeit.py
@@ -1,0 +1,129 @@
+"""Unit tests for Quartierüblichkeit comparables math (OR Art. 270)."""
+import datetime
+from types import SimpleNamespace
+
+from strata_api.legal.quartierueblichkeit import (
+    Verdict,
+    analyze_initial_rent,
+    select_comparables,
+)
+
+NOW = datetime.datetime(2026, 7, 1)
+
+
+def _listing(**kw) -> SimpleNamespace:
+    base = dict(id=0, rooms=3.0, area_m2=80.0, rent_net=2000, plz=8005, last_seen=NOW)
+    base.update(kw)
+    return SimpleNamespace(**base)
+
+
+def _comparable(chf_per_m2: float, cid: int) -> SimpleNamespace:
+    """Comparable with area 100 m² so rent_net/area == the requested CHF/m²."""
+    return _listing(id=cid, area_m2=100.0, rent_net=chf_per_m2 * 100, rooms=3.0, plz=8005)
+
+
+# --- selection filters --------------------------------------------------------
+
+def test_select_comparables_applies_all_filters():
+    target = _listing(id=1, rooms=3.0, area_m2=80.0, plz=8005)
+    candidates = [
+        _listing(id=2, area_m2=85.0),                                   # OK
+        _listing(id=1),                                                 # self -> excluded
+        _listing(id=3, rent_net=None),                                  # no rent -> excluded
+        _listing(id=4, area_m2=None),                                   # no area -> excluded
+        _listing(id=5, plz=8006),                                       # different PLZ -> excluded
+        _listing(id=6, rooms=4.0),                                      # rooms +1.0 -> excluded
+        _listing(id=7, area_m2=100.0),                                  # 100 > 96 -> excluded
+        _listing(id=8, last_seen=datetime.datetime(2024, 1, 1)),        # too old -> excluded
+        _listing(id=9, rooms=3.5),                                      # rooms edge 0.5 -> OK
+        _listing(id=10, area_m2=96.0),                                  # area edge +20% -> OK
+    ]
+    selected = select_comparables(target, candidates, now=NOW)
+    assert {c.id for c in selected} == {2, 9, 10}
+
+
+def test_select_comparables_empty_when_target_has_no_area():
+    target = _listing(id=1, area_m2=None)
+    assert select_comparables(target, [_listing(id=2)], now=NOW) == []
+
+
+def test_select_comparables_recency_edge_inclusive():
+    target = _listing(id=1)
+    # exactly 24 calendar months before NOW -> included (>= cutoff)
+    on_edge = _listing(id=2, last_seen=datetime.datetime(2024, 7, 1))
+    assert {c.id for c in select_comparables(target, [on_edge], now=NOW)} == {2}
+
+
+# --- percentile / verdict math (pinned) --------------------------------------
+# Comparable CHF/m² set: [20, 22, 24, 25, 26, 28, 30, 32], N=8
+#   median = (25 + 26) / 2 = 25.5
+#   p25 (nearest-rank, ceil(0.25*8)=2) -> 22
+#   p75 (nearest-rank, ceil(0.75*8)=6) -> 28
+#   p75 * 1.10 = 30.8
+_EIGHT = [20, 22, 24, 25, 26, 28, 30, 32]
+
+
+def _eight_comparables() -> list[SimpleNamespace]:
+    return [_comparable(v, cid=100 + i) for i, v in enumerate(_EIGHT)]
+
+
+def test_pinned_percentiles():
+    target = _comparable(25.0, cid=1)
+    result = analyze_initial_rent(target, _eight_comparables())
+    assert result.comparable_count == 8
+    assert result.median_chf_m2 == 25.5
+    assert result.p25_chf_m2 == 22.0
+    assert result.p75_chf_m2 == 28.0
+
+
+def test_verdict_within_range_at_p75_boundary():
+    target = _comparable(28.0, cid=1)  # == p75 -> within range (<=)
+    result = analyze_initial_rent(target, _eight_comparables())
+    assert result.verdict is Verdict.WITHIN_RANGE
+    assert result.target_chf_m2 == 28.0
+
+
+def test_verdict_above_market_at_upper_boundary():
+    target = _comparable(30.8, cid=1)  # == p75 * 1.10 -> above_market (<=)
+    result = analyze_initial_rent(target, _eight_comparables())
+    assert result.verdict is Verdict.ABOVE_MARKET
+
+
+def test_verdict_clearly_above_market_just_over_threshold():
+    target = _comparable(31.0, cid=1)  # > p75 * 1.10 (30.8) -> clearly above
+    result = analyze_initial_rent(target, _eight_comparables())
+    assert result.verdict is Verdict.CLEARLY_ABOVE_MARKET
+
+
+def test_verdict_within_range_below_median():
+    target = _comparable(21.0, cid=1)
+    result = analyze_initial_rent(target, _eight_comparables())
+    assert result.verdict is Verdict.WITHIN_RANGE
+
+
+def test_insufficient_data_below_minimum():
+    target = _comparable(30.0, cid=1)
+    result = analyze_initial_rent(target, _eight_comparables()[:4])  # only 4
+    assert result.verdict is Verdict.INSUFFICIENT_DATA
+    assert result.comparable_count == 4
+    assert result.median_chf_m2 is None
+    assert "minimum 5" in result.explanation
+
+
+def test_insufficient_data_when_target_missing_fields():
+    target = _listing(id=1, rent_net=None, area_m2=None)
+    result = analyze_initial_rent(target, _eight_comparables())
+    assert result.verdict is Verdict.INSUFFICIENT_DATA
+    assert result.target_chf_m2 is None
+
+
+# --- explanation --------------------------------------------------------------
+
+def test_explanation_contains_key_figures_and_disclaimer():
+    target = _comparable(30.8, cid=1)
+    result = analyze_initial_rent(target, _eight_comparables())
+    assert "30.8" in result.explanation          # asking CHF/m²
+    assert "25.5" in result.explanation          # median
+    assert "28.0" in result.explanation          # p75
+    assert "8 comparable" in result.explanation  # count
+    assert "not legal advice" in result.explanation

--- a/apps/api/tests/routers/test_referenzzins.py
+++ b/apps/api/tests/routers/test_referenzzins.py
@@ -146,3 +146,123 @@ async def test_generate_letter_no_reduction_conflict(legal_client):
     }
     r = await legal_client.post("/legal/listings/3/herabsetzungsbegehren", json=payload)
     assert r.status_code == 409
+
+
+# --- Initial-rent check (OR Art. 270) ----------------------------------------
+# Comparable CHF/m² set (area 80 m² -> rent = value * 80): [20,22,24,25,26,28,30,32]
+#   median 25.5, p25 22, p75 28, p75*1.10 = 30.8
+_IR_CHF = [20, 22, 24, 25, 26, 28, 30, 32]
+
+
+def _seed_quarter(session, plz: int, base_id: int, now):
+    """Seed 8 comparable listings in one PLZ (rooms 3.0, area 80 m²)."""
+    for i, chf in enumerate(_IR_CHF):
+        session.add(Listing(
+            id=base_id + i, source="flatfox", source_id=f"IR-{base_id + i}",
+            rent_net=chf * 80, rooms=3.0, area_m2=80.0, plz=plz, city="Zürich",
+            first_seen=now, last_seen=now, is_active=True,
+        ))
+
+
+@pytest.fixture(scope="module")
+def ir_engine():
+    eng = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(eng)
+    now = datetime.datetime.utcnow()
+    with Session(eng) as s:
+        # Each scenario gets its own PLZ so targets never pollute each other's pool.
+        _seed_quarter(s, plz=8020, base_id=1000, now=now)  # within-range quarter
+        _seed_quarter(s, plz=8021, base_id=1100, now=now)  # above-market quarter
+        _seed_quarter(s, plz=8022, base_id=1200, now=now)  # clearly-above quarter
+
+        # Targets (rooms 3.0, area 80) hitting each verdict.
+        s.add(Listing(id=2000, source="flatfox", source_id="T-within",
+                      rent_net=2000, rooms=3.0, area_m2=80.0, plz=8020, city="Zürich",
+                      first_seen=now, last_seen=now, is_active=True))  # 25.0 -> within_range
+        s.add(Listing(id=2001, source="flatfox", source_id="T-above",
+                      rent_net=2400, rooms=3.0, area_m2=80.0, plz=8021, city="Zürich",
+                      first_seen=now, last_seen=now, is_active=True))  # 30.0 -> above_market
+        s.add(Listing(id=2002, source="flatfox", source_id="T-clearly",
+                      rent_net=2560, rooms=3.0, area_m2=80.0, plz=8022, city="Zürich",
+                      first_seen=now, last_seen=now, is_active=True))  # 32.0 -> clearly_above
+
+        # Insufficient-data quarter: only 3 comparables + a target.
+        for i, chf in enumerate([24, 26, 28]):
+            s.add(Listing(id=1300 + i, source="flatfox", source_id=f"IR-{1300 + i}",
+                          rent_net=chf * 80, rooms=3.0, area_m2=80.0, plz=8023, city="Zürich",
+                          first_seen=now, last_seen=now, is_active=True))
+        s.add(Listing(id=2003, source="flatfox", source_id="T-sparse",
+                      rent_net=2400, rooms=3.0, area_m2=80.0, plz=8023, city="Zürich",
+                      first_seen=now, last_seen=now, is_active=True))
+
+        # Target missing area/rent -> insufficient_data, never 500.
+        s.add(Listing(id=2004, source="flatfox", source_id="T-noarea",
+                      rent_net=2400, rooms=3.0, area_m2=None, plz=8020, city="Zürich",
+                      first_seen=now, last_seen=now, is_active=True))
+        s.commit()
+    return eng
+
+
+@pytest.fixture
+async def ir_client(ir_engine):
+    with patch("strata_api.routers.referenzzins.get_engine", return_value=ir_engine):
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+            yield ac
+
+
+async def test_initial_rent_check_unknown_listing(ir_client):
+    r = await ir_client.get("/legal/listings/999999/initial-rent-check")
+    assert r.status_code == 404
+
+
+async def test_initial_rent_check_within_range(ir_client):
+    r = await ir_client.get("/legal/listings/2000/initial-rent-check")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["verdict"] == "within_range"
+    assert body["target_chf_m2"] == 25.0
+    assert body["median_chf_m2"] == 25.5
+    assert body["p25"] == 22.0
+    assert body["p75"] == 28.0
+    assert body["comparable_count"] == 8
+    assert body["or270"]["deadline_days"] == 30
+    assert "Schlichtungsbehörde" in body["or270"]["schlichtungsbehoerde"]
+
+
+async def test_initial_rent_check_above_market(ir_client):
+    r = await ir_client.get("/legal/listings/2001/initial-rent-check")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["verdict"] == "above_market"
+    assert body["target_chf_m2"] == 30.0
+
+
+async def test_initial_rent_check_clearly_above_market(ir_client):
+    r = await ir_client.get("/legal/listings/2002/initial-rent-check")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["verdict"] == "clearly_above_market"
+    assert body["target_chf_m2"] == 32.0
+    assert "clearly" in body["explanation"].lower()
+
+
+async def test_initial_rent_check_insufficient_data(ir_client):
+    r = await ir_client.get("/legal/listings/2003/initial-rent-check")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["verdict"] == "insufficient_data"
+    assert body["comparable_count"] == 3
+    assert body["median_chf_m2"] is None
+
+
+async def test_initial_rent_check_missing_area_is_insufficient_not_500(ir_client):
+    r = await ir_client.get("/legal/listings/2004/initial-rent-check")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["verdict"] == "insufficient_data"
+    assert body["target_chf_m2"] is None
+    assert "no net rent" in body["explanation"].lower() or "area" in body["explanation"].lower()


### PR DESCRIPTION
Layer 7 Legal Intelligence, third feature — estimates whether a listing's asking rent is defensible vs. quarter-customary rents, per the vision's "Before You Sign" section. Built TDD by an Opus 4.8 agent, reviewed and shipped by the orchestrator (autonomous dev loop, iteration 7).

## What
`GET /legal/listings/{id}/initial-rent-check` compares the listing's CHF/m² against comparable listings (same PLZ, rooms ±0.5, area ±20%, seen within 24 months) from Strata's own corpus:

| Verdict | Condition |
|---|---|
| `within_range` | ≤ p75 of comparables |
| `above_market` | p75 < target ≤ p75 × 1.10 |
| `clearly_above_market` | > p75 × 1.10 |
| `insufficient_data` | < 5 comparables, or listing missing rent/area |

Response includes target/median/p25/p75 CHF/m², comparable count, a human-readable explanation with the figures, and the OR Art. 270 info block (30-day contest window, conditions, Schlichtungsbehörde pointer, not-legal-advice disclaimer — single reviewed copy source in `legal/or270.py`).

## Design choices
- **Deliberately conservative**: `clearly_above_market` requires beating p75 by 10% — favors silence over wrongly implying a contestable rent. Documented in-module.
- **≥5 comparables** mirrors the courts' five-comparable-objects minimum for the absolute method.
- Pure math in `legal/` (no DB), thin PLZ+recency query in the router; degrades to 200 + explanation, never 500.

## Testing
+24 tests → **727 backend total** (incl. merged green pipeline), zero regressions; `ruff check` clean; percentile math pinned to exact expected values at every verdict boundary.

## Follow-ups
- Frontend surface (badge next to the Herabsetzung badge; "rent looks high for this quarter")
- Quartier-polygon comparables (PLZ is the v1 proxy)