### PR TITLE
feat: rent trends per Quartier from the listings corpus

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -27,7 +27,7 @@ Update this file when phases shift. Claude Code reads it every session via CLAUD
 | Photos stored | 565+ |
 | Quartiere with profiles | 34 |
 | Noise data points | 1,071,340 |
-| Backend tests | 729 |
+| Backend tests | 744 |
 | Frontend tests | 367 |
 
 ---
@@ -84,7 +84,7 @@ The layer that answers "where should I live?" Four dimensions.
 |-----------|--------|-------------|-------|
 | **Population growth/decline** | 🟢 Done | YoY from demographics CSV (back to 1993) | — |
 | **Construction activity** | 🟢 Done | GWR construction year distribution per Quartier | — |
-| **Rent trends per Quartier** | 🟡 Partial | From listing data (need historical depth) | #TBD |
+| **Rent trends per Quartier** | 🟢 Pipeline done — `--rents`: median CHF/m² + 12-month monthly trend per quartier from own listings corpus | — |
 | **Commercial activity** (new venues opening) | 💡 Idea | Handelsregister or OSM changeset history | #TBD |
 | **Construction pipeline** (approved + under construction per Quartier) | 🟢 Done — OGD BAU501OD5011, profile + comparison + vibe | — |
 

--- a/apps/api/src/strata_api/pipeline/neighborhoods/__main__.py
+++ b/apps/api/src/strata_api/pipeline/neighborhoods/__main__.py
@@ -1,7 +1,7 @@
 """CLI entry point for the neighborhood intelligence pipeline.
 
 Usage:
-    uv run python -m strata_api.pipeline.neighborhoods [--amenities] [--green]
+    uv run python -m strata_api.pipeline.neighborhoods [--amenities] [--green] [--rents]
 
 Writes quartiere.geojson + noise.geojson + green_spaces.geojson to
 apps/web/public/data and copies quartiere.geojson to apps/api/data/neighborhoods
@@ -10,6 +10,8 @@ for the API router.
 amenities_raw.json in the output dir is reused if present).
 --green fetches OSM green space from Overpass (otherwise a cached
 green_raw.json in the output dir is reused if present).
+--rents computes per-quartier asking-rent statistics from the listings DB
+(requires DATABASE_URL to point at a populated database).
 """
 from __future__ import annotations
 
@@ -31,6 +33,7 @@ def main() -> None:
     parser.add_argument("--api-data", type=Path, default=DEFAULT_API_DATA_DIR, help="API data directory")
     parser.add_argument("--amenities", action="store_true", help="Fetch OSM amenities from Overpass")
     parser.add_argument("--green", action="store_true", help="Fetch OSM green space from Overpass")
+    parser.add_argument("--rents", action="store_true", help="Compute per-quartier rent stats from the listings DB")
     parser.add_argument("--skip-noise", action="store_true", help="Skip the slow noise cadastre download")
     args = parser.parse_args()
 
@@ -40,6 +43,7 @@ def main() -> None:
         api_data_dir=args.api_data,
         fetch_amenities=args.amenities,
         fetch_green=args.green,
+        include_rents=args.rents,
         skip_noise=args.skip_noise,
     )
     logging.getLogger(__name__).info("Pipeline complete: %s", stats)

--- a/apps/api/src/strata_api/pipeline/neighborhoods/aggregator.py
+++ b/apps/api/src/strata_api/pipeline/neighborhoods/aggregator.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from strata_api.pipeline.neighborhoods.demographics_parser import QuartierDemographics
     from strata_api.pipeline.neighborhoods.quartier_parser import QuartierRecord
+    from strata_api.pipeline.neighborhoods.rent_trends import RentStats
 
 # Lazy import: only used when otp_base_url is provided
 _compute_commute: object = None  # populated on first use
@@ -100,6 +101,17 @@ def _green_props(metrics: dict | None) -> dict:
     return {key: metrics.get(key) for key in _GREEN_KEYS}
 
 
+def _rent_props(stats: RentStats | None) -> dict:
+    """Flatten RentStats (see rent_trends.py) into properties, or None each when absent."""
+    if stats is None:
+        return {"rent_median_chf_m2": None, "rent_listing_count": None, "rent_trend": None}
+    return {
+        "rent_median_chf_m2": stats.median_chf_m2,
+        "rent_listing_count": stats.listing_count,
+        "rent_trend": list(stats.trend),
+    }
+
+
 def aggregate_quartier_geojson(
     quartier_records: dict[int, QuartierRecord],
     demographics: dict[int, QuartierDemographics],
@@ -107,6 +119,7 @@ def aggregate_quartier_geojson(
     amenities: dict[int, dict[str, int]] | None = None,
     construction: dict[int, dict] | None = None,
     green: dict[int, dict] | None = None,
+    rents: dict[int, RentStats] | None = None,
 ) -> dict:
     """Produce an enriched GeoJSON FeatureCollection.
 
@@ -151,11 +164,12 @@ def aggregate_quartier_geojson(
         amenity_p = _amenity_props(amenities.get(qid) if amenities is not None else None, rec.area_km2)
         construction_p = {"construction": construction.get(qid) if construction is not None else None}
         green_p = _green_props(green.get(qid) if green is not None else None)
+        rent_p = _rent_props(rents.get(qid) if rents is not None else None)
 
         features.append({
             "type": "Feature",
             "geometry": rec.geometry,
-            "properties": {**base_props, **demo_p, **commute_p, **amenity_p, **construction_p, **green_p},
+            "properties": {**base_props, **demo_p, **commute_p, **amenity_p, **construction_p, **green_p, **rent_p},
         })
 
     # Vibe profiles need the full city distribution — computed as a second pass

--- a/apps/api/src/strata_api/pipeline/neighborhoods/amenities.py
+++ b/apps/api/src/strata_api/pipeline/neighborhoods/amenities.py
@@ -119,36 +119,9 @@ def fetch_overpass_amenities(bbox: tuple[float, float, float, float] = ZURICH_BB
     raise RuntimeError("unreachable")
 
 
-# ── Point-in-polygon (pure python ray casting, WGS84 lon/lat) ────────────────
-
-
-def _point_in_ring(lon: float, lat: float, ring: list) -> bool:
-    inside = False
-    j = len(ring) - 1
-    for i in range(len(ring)):
-        xi, yi = ring[i][0], ring[i][1]
-        xj, yj = ring[j][0], ring[j][1]
-        if (yi > lat) != (yj > lat) and lon < (xj - xi) * (lat - yi) / (yj - yi) + xi:
-            inside = not inside
-        j = i
-    return inside
-
-
-def _point_in_polygon(lon: float, lat: float, rings: list) -> bool:
-    if not rings or not _point_in_ring(lon, lat, rings[0]):
-        return False
-    # Inside the exterior ring — check it is not inside a hole
-    return not any(_point_in_ring(lon, lat, hole) for hole in rings[1:])
-
-
-def point_in_geometry(lon: float, lat: float, geometry: dict) -> bool:
-    """True if (lon, lat) falls inside a GeoJSON Polygon or MultiPolygon."""
-    gtype = geometry.get("type")
-    if gtype == "Polygon":
-        return _point_in_polygon(lon, lat, geometry.get("coordinates", []))
-    if gtype == "MultiPolygon":
-        return any(_point_in_polygon(lon, lat, rings) for rings in geometry.get("coordinates", []))
-    return False
+# Point-in-polygon lives in the shared geometry module; re-exported here for
+# back-compat (green_space and older callers import it from amenities).
+from strata_api.pipeline.neighborhoods.geometry import point_in_geometry  # noqa: E402, F401
 
 
 def count_amenities_per_quartier(

--- a/apps/api/src/strata_api/pipeline/neighborhoods/geometry.py
+++ b/apps/api/src/strata_api/pipeline/neighborhoods/geometry.py
@@ -1,0 +1,35 @@
+"""Shared point-in-polygon containment helpers (pure python ray casting, WGS84 lon/lat).
+
+Extracted from amenities.py so amenities, green_space and rent_trends all share a
+single implementation for assigning points to Quartier boundaries.
+"""
+from __future__ import annotations
+
+
+def _point_in_ring(lon: float, lat: float, ring: list) -> bool:
+    inside = False
+    j = len(ring) - 1
+    for i in range(len(ring)):
+        xi, yi = ring[i][0], ring[i][1]
+        xj, yj = ring[j][0], ring[j][1]
+        if (yi > lat) != (yj > lat) and lon < (xj - xi) * (lat - yi) / (yj - yi) + xi:
+            inside = not inside
+        j = i
+    return inside
+
+
+def _point_in_polygon(lon: float, lat: float, rings: list) -> bool:
+    if not rings or not _point_in_ring(lon, lat, rings[0]):
+        return False
+    # Inside the exterior ring — check it is not inside a hole
+    return not any(_point_in_ring(lon, lat, hole) for hole in rings[1:])
+
+
+def point_in_geometry(lon: float, lat: float, geometry: dict) -> bool:
+    """True if (lon, lat) falls inside a GeoJSON Polygon or MultiPolygon."""
+    gtype = geometry.get("type")
+    if gtype == "Polygon":
+        return _point_in_polygon(lon, lat, geometry.get("coordinates", []))
+    if gtype == "MultiPolygon":
+        return any(_point_in_polygon(lon, lat, rings) for rings in geometry.get("coordinates", []))
+    return False

--- a/apps/api/src/strata_api/pipeline/neighborhoods/rent_trends.py
+++ b/apps/api/src/strata_api/pipeline/neighborhoods/rent_trends.py
@@ -1,0 +1,172 @@
+"""Asking-rent statistics per Quartier from Strata's own listings corpus.
+
+Produces, per Quartier:
+  - rent_median_chf_m2:  median asking CHF/m² over *active* listings
+  - rent_listing_count:  number of active listings behind that median
+  - rent_trend:          monthly median CHF/m² over the last TREND_MONTHS months —
+                         a listing counts in every month of its first_seen..last_seen
+                         span; months with fewer than MIN_MONTHLY_N listings are omitted
+
+Approximations (deliberate, documented):
+  - Each listing uses its *final* rent_net across its whole visibility span;
+    intermediate price changes in listing_history are not replayed. Asking-rent
+    levels move slowly enough for a v1 trend line.
+  - Quartier assignment is point-in-polygon on the listing's coordinates.
+    Listings without coordinates, or outside every Quartier polygon, are skipped
+    (counts logged) — no PLZ fallback, since PLZ↔Quartier is not a clean mapping.
+  - Implausible records are excluded: rent_net <= 0 or area below MIN_AREA_M2.
+"""
+from __future__ import annotations
+
+import datetime
+import logging
+import statistics
+from dataclasses import dataclass
+
+from sqlalchemy import Engine, select
+from sqlalchemy.orm import Session
+
+from strata_api.pipeline.neighborhoods.geometry import point_in_geometry
+from strata_api.pipeline.neighborhoods.quartier_parser import QuartierRecord
+
+logger = logging.getLogger(__name__)
+
+MIN_AREA_M2 = 8.0     # below this, area is a data error and CHF/m² is meaningless
+MIN_MONTHLY_N = 3     # a monthly median needs at least this many listings
+TREND_MONTHS = 12     # trend window, counting back from `now` inclusive
+
+
+@dataclass(frozen=True)
+class ListingObservation:
+    """The slice of a listing relevant to rent statistics."""
+
+    rent_net: int | None
+    area_m2: float | None
+    lng: float | None
+    lat: float | None
+    first_seen: datetime.datetime
+    last_seen: datetime.datetime
+    is_active: bool
+
+
+@dataclass(frozen=True)
+class RentStats:
+    """Per-quartier rent statistics, ready for GeoJSON property merging."""
+
+    median_chf_m2: float | None
+    listing_count: int
+    trend: tuple[dict, ...]  # ({"month": "YYYY-MM", "median_chf_m2": float, "n": int}, ...)
+
+
+def chf_per_m2(rent_net: int | None, area_m2: float | None) -> float | None:
+    """Asking rent per m², or None when inputs are missing or implausible."""
+    if rent_net is None or area_m2 is None:
+        return None
+    if rent_net <= 0 or area_m2 < MIN_AREA_M2:
+        return None
+    return round(rent_net / area_m2, 2)
+
+
+def months_spanned(first_seen: datetime.datetime, last_seen: datetime.datetime) -> list[str]:
+    """All "YYYY-MM" months the span touches, inclusive on both ends, ascending."""
+    months: list[str] = []
+    year, month = first_seen.year, first_seen.month
+    while (year, month) <= (last_seen.year, last_seen.month):
+        months.append(f"{year:04d}-{month:02d}")
+        month += 1
+        if month > 12:
+            year, month = year + 1, 1
+    return months
+
+
+def _window_months(now: datetime.datetime) -> list[str]:
+    """The last TREND_MONTHS months ending at `now`'s month, ascending."""
+    year, month = now.year, now.month
+    months: list[str] = []
+    for _ in range(TREND_MONTHS):
+        months.append(f"{year:04d}-{month:02d}")
+        month -= 1
+        if month < 1:
+            year, month = year - 1, 12
+    return sorted(months)
+
+
+def _assign_quartier(obs: ListingObservation, quartiers: dict[int, QuartierRecord]) -> int | None:
+    if obs.lng is None or obs.lat is None:
+        return None
+    for qid, rec in quartiers.items():
+        if point_in_geometry(obs.lng, obs.lat, rec.geometry):
+            return qid
+    return None
+
+
+def compute_rent_stats(
+    listings: list[ListingObservation],
+    quartiers: dict[int, QuartierRecord],
+    now: datetime.datetime,
+) -> dict[int, RentStats]:
+    """Compute current-level and monthly-trend rent statistics per Quartier."""
+    window = set(_window_months(now))
+    current: dict[int, list[float]] = {qid: [] for qid in quartiers}
+    monthly: dict[int, dict[str, list[float]]] = {qid: {} for qid in quartiers}
+
+    skipped_value = skipped_coords = skipped_outside = 0
+    for obs in listings:
+        value = chf_per_m2(obs.rent_net, obs.area_m2)
+        if value is None:
+            skipped_value += 1
+            continue
+        if obs.lng is None or obs.lat is None:
+            skipped_coords += 1
+            continue
+        qid = _assign_quartier(obs, quartiers)
+        if qid is None:
+            skipped_outside += 1
+            continue
+
+        if obs.is_active:
+            current[qid].append(value)
+        for month in months_spanned(obs.first_seen, obs.last_seen):
+            if month in window:
+                monthly[qid].setdefault(month, []).append(value)
+
+    if skipped_value or skipped_coords or skipped_outside:
+        logger.info(
+            "rent_trends: skipped %d listings with implausible rent/area, %d without coordinates, %d outside all quartiers",
+            skipped_value, skipped_coords, skipped_outside,
+        )
+
+    stats: dict[int, RentStats] = {}
+    for qid in quartiers:
+        values = current[qid]
+        trend = tuple(
+            {"month": month, "median_chf_m2": round(statistics.median(vals), 2), "n": len(vals)}
+            for month, vals in sorted(monthly[qid].items())
+            if len(vals) >= MIN_MONTHLY_N
+        )
+        stats[qid] = RentStats(
+            median_chf_m2=round(statistics.median(values), 2) if values else None,
+            listing_count=len(values),
+            trend=trend,
+        )
+    return stats
+
+
+def load_listing_observations(engine: Engine) -> list[ListingObservation]:
+    """Load the rent-relevant listing slice from the database."""
+    from strata_api.db.models.listing import Listing
+
+    with Session(engine) as session:
+        rows = session.execute(
+            select(
+                Listing.rent_net, Listing.area_m2, Listing.lng, Listing.lat,
+                Listing.first_seen, Listing.last_seen, Listing.is_active,
+            )
+        ).all()
+    return [
+        ListingObservation(
+            rent_net=r.rent_net, area_m2=r.area_m2, lng=r.lng, lat=r.lat,
+            first_seen=r.first_seen, last_seen=r.last_seen, is_active=r.is_active,
+        )
+        for r in rows
+    ]

--- a/apps/api/src/strata_api/pipeline/neighborhoods/runner.py
+++ b/apps/api/src/strata_api/pipeline/neighborhoods/runner.py
@@ -36,6 +36,7 @@ def run_neighborhood_pipeline(
     api_data_dir: Path | None = None,
     fetch_amenities: bool = False,
     fetch_green: bool = False,
+    include_rents: bool = False,
     skip_noise: bool = False,
 ) -> dict:
     """Orchestrate the neighborhood intelligence pipeline.
@@ -158,9 +159,27 @@ def run_neighborhood_pipeline(
         green_area_count = sum(1 for m in green_metrics.values() if m["green_area_m2"] > 0)
         logger.info("Parsed %d green polygons; %d quartiere have green area", len(green_areas), green_area_count)
 
+    # ── Rent trends (reads the listings DB; only when asked) ────────────────
+    rent_stats = None
+    if include_rents:
+        import datetime
+
+        from strata_api.db.session import get_engine
+        from strata_api.pipeline.neighborhoods.rent_trends import compute_rent_stats, load_listing_observations
+
+        try:
+            observations = load_listing_observations(get_engine())
+            rent_stats = compute_rent_stats(observations, quartier_records, now=datetime.datetime.utcnow())
+            with_rents = sum(1 for s in rent_stats.values() if s.median_chf_m2 is not None)
+            logger.info("Computed rent stats from %d listings; %d quartiere have medians", len(observations), with_rents)
+        except Exception:
+            logger.exception("Rent-trends step failed; continuing without rent properties")
+            rent_stats = None
+
     logger.info("Aggregating into GeoJSON...")
     geojson = aggregate_quartier_geojson(
-        quartier_records, demographics, amenities=amenity_counts, construction=construction, green=green_metrics
+        quartier_records, demographics, amenities=amenity_counts, construction=construction, green=green_metrics,
+        rents=rent_stats,
     )
 
     quartiere_path = output_dir / "quartiere.geojson"
@@ -195,4 +214,7 @@ def run_neighborhood_pipeline(
         "construction_quartiere": len(construction),
         "green_areas": green_area_count,
         "green_polygons": len(green_geojson["features"]) if green_geojson is not None else None,
+        "rent_quartiere": (
+            sum(1 for s in rent_stats.values() if s.median_chf_m2 is not None) if rent_stats is not None else None
+        ),
     }

--- a/apps/api/tests/pipeline/neighborhoods/test_aggregator.py
+++ b/apps/api/tests/pipeline/neighborhoods/test_aggregator.py
@@ -345,3 +345,37 @@ class TestVibeInAggregator:
         records = {11: _make_quartier(11, "Rathaus", 1)}
         result = aggregate_quartier_geojson(records, {})
         assert result["features"][0]["properties"]["vibe"] is None
+
+
+class TestRentProps:
+    """Rent-trend properties merged into quartier features (see rent_trends.py)."""
+
+    def test_rent_keys_none_when_not_provided(self):
+        from strata_api.pipeline.neighborhoods.aggregator import aggregate_quartier_geojson
+
+        records = {11: _make_quartier(11, "Rathaus", 1)}
+        result = aggregate_quartier_geojson(records, {11: _make_demo(11)})
+        props = result["features"][0]["properties"]
+        assert props["rent_median_chf_m2"] is None
+        assert props["rent_listing_count"] is None
+        assert props["rent_trend"] is None
+
+    def test_rent_stats_merged(self):
+        from strata_api.pipeline.neighborhoods.aggregator import aggregate_quartier_geojson
+        from strata_api.pipeline.neighborhoods.rent_trends import RentStats
+
+        records = {11: _make_quartier(11, "Rathaus", 1), 12: _make_quartier(12, "Lindenhof", 1)}
+        rents = {
+            11: RentStats(
+                median_chf_m2=31.5,
+                listing_count=14,
+                trend=({"month": "2026-06", "median_chf_m2": 31.0, "n": 12},),
+            )
+        }
+        result = aggregate_quartier_geojson(records, {11: _make_demo(11)}, rents=rents)
+        by_id = {f["properties"]["quartier_id"]: f["properties"] for f in result["features"]}
+        assert by_id[11]["rent_median_chf_m2"] == 31.5
+        assert by_id[11]["rent_listing_count"] == 14
+        assert by_id[11]["rent_trend"] == [{"month": "2026-06", "median_chf_m2": 31.0, "n": 12}]
+        assert by_id[12]["rent_median_chf_m2"] is None
+        assert by_id[12]["rent_trend"] is None

--- a/apps/api/tests/pipeline/neighborhoods/test_rent_trends.py
+++ b/apps/api/tests/pipeline/neighborhoods/test_rent_trends.py
@@ -1,0 +1,153 @@
+"""Tests for the rent-trends step (asking-rent CHF/m² per Quartier from the listings corpus)."""
+from __future__ import annotations
+
+import datetime
+
+from strata_api.pipeline.neighborhoods.quartier_parser import QuartierRecord
+from strata_api.pipeline.neighborhoods.rent_trends import (
+    MIN_AREA_M2,
+    MIN_MONTHLY_N,
+    TREND_MONTHS,
+    ListingObservation,
+    chf_per_m2,
+    compute_rent_stats,
+    months_spanned,
+)
+
+NOW = datetime.datetime(2026, 7, 1, 12, 0)
+
+# Two adjacent unit-square quartiers: A spans lon 0..1, B spans lon 1..2 (lat 0..1).
+_QUARTIER_A = QuartierRecord(
+    quartier_id=1, quartier_name="A", kreis=1, area_km2=1.0,
+    geometry={"type": "Polygon", "coordinates": [[[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]]},
+)
+_QUARTIER_B = QuartierRecord(
+    quartier_id=2, quartier_name="B", kreis=1, area_km2=1.0,
+    geometry={"type": "Polygon", "coordinates": [[[1, 0], [2, 0], [2, 1], [1, 1], [1, 0]]]},
+)
+QUARTIERE = {1: _QUARTIER_A, 2: _QUARTIER_B}
+
+
+def _obs(rent=2000, area=80.0, lng=0.5, lat=0.5, first=None, last=None, active=True):
+    return ListingObservation(
+        rent_net=rent,
+        area_m2=area,
+        lng=lng,
+        lat=lat,
+        first_seen=first or NOW - datetime.timedelta(days=10),
+        last_seen=last or NOW,
+        is_active=active,
+    )
+
+
+# ── chf_per_m2 ──
+def test_chf_per_m2_basic():
+    assert chf_per_m2(2000, 80.0) == 25.0
+
+
+def test_chf_per_m2_excludes_bad_inputs():
+    assert chf_per_m2(None, 80.0) is None
+    assert chf_per_m2(2000, None) is None
+    assert chf_per_m2(0, 80.0) is None
+    assert chf_per_m2(-5, 80.0) is None
+    assert chf_per_m2(2000, MIN_AREA_M2 - 0.5) is None  # implausibly small area
+
+
+# ── months_spanned ──
+def test_months_spanned_single_month():
+    months = months_spanned(datetime.datetime(2026, 6, 3), datetime.datetime(2026, 6, 20))
+    assert months == ["2026-06"]
+
+
+def test_months_spanned_across_months():
+    months = months_spanned(datetime.datetime(2026, 4, 25), datetime.datetime(2026, 6, 2))
+    assert months == ["2026-04", "2026-05", "2026-06"]
+
+
+def test_months_spanned_across_year_boundary():
+    months = months_spanned(datetime.datetime(2025, 12, 15), datetime.datetime(2026, 1, 10))
+    assert months == ["2025-12", "2026-01"]
+
+
+# ── compute_rent_stats: current level ──
+def test_current_median_over_active_listings():
+    listings = [
+        _obs(rent=2000, area=80.0),   # 25.0
+        _obs(rent=2700, area=90.0),   # 30.0
+        _obs(rent=3500, area=100.0),  # 35.0
+        _obs(rent=9999, area=100.0, active=False),  # inactive → excluded from current level
+    ]
+    stats = compute_rent_stats(listings, QUARTIERE, now=NOW)
+    assert stats[1].median_chf_m2 == 30.0
+    assert stats[1].listing_count == 3
+
+
+def test_quartier_without_listings_gets_none():
+    stats = compute_rent_stats([_obs(lng=0.5)], QUARTIERE, now=NOW)
+    assert stats[2].median_chf_m2 is None
+    assert stats[2].listing_count == 0
+    assert stats[2].trend == ()
+
+
+def test_assignment_is_point_in_polygon():
+    listings = [_obs(lng=0.5), _obs(lng=1.5, rent=4000, area=100.0)]
+    stats = compute_rent_stats(listings, QUARTIERE, now=NOW)
+    assert stats[1].listing_count == 1
+    assert stats[2].listing_count == 1
+    assert stats[2].median_chf_m2 == 40.0
+
+
+def test_coordless_and_outside_listings_skipped():
+    listings = [
+        _obs(lng=None, lat=None),      # no coords
+        _obs(lng=50.0, lat=50.0),      # outside every quartier
+        _obs(),                        # valid
+    ]
+    stats = compute_rent_stats(listings, QUARTIERE, now=NOW)
+    assert stats[1].listing_count == 1
+
+
+# ── compute_rent_stats: trend ──
+def test_trend_buckets_span_months_with_min_n():
+    first = datetime.datetime(2026, 5, 10)
+    listings = [
+        _obs(rent=2000, area=80.0, first=first, last=NOW),   # 25.0 in May, Jun, Jul
+        _obs(rent=2400, area=80.0, first=first, last=NOW),   # 30.0
+        _obs(rent=2800, area=80.0, first=first, last=NOW),   # 35.0
+        # Only present in June → June has n=4, others n=3
+        _obs(rent=4000, area=100.0, first=datetime.datetime(2026, 6, 5), last=datetime.datetime(2026, 6, 25)),
+    ]
+    stats = compute_rent_stats(listings, QUARTIERE, now=NOW)
+    trend = {point["month"]: point for point in stats[1].trend}
+    assert trend["2026-05"]["median_chf_m2"] == 30.0
+    assert trend["2026-05"]["n"] == 3
+    assert trend["2026-06"]["n"] == 4
+    assert trend["2026-06"]["median_chf_m2"] == 32.5  # median of 25, 30, 35, 40
+
+
+def test_trend_months_below_min_n_omitted():
+    listings = [_obs(), _obs(rent=2400)]  # only 2 listings → below MIN_MONTHLY_N
+    assert MIN_MONTHLY_N == 3
+    stats = compute_rent_stats(listings, QUARTIERE, now=NOW)
+    assert stats[1].trend == ()
+
+
+def test_trend_clipped_to_window():
+    old_first = NOW - datetime.timedelta(days=800)
+    listings = [
+        _obs(first=old_first, last=NOW),
+        _obs(rent=2400, first=old_first, last=NOW),
+        _obs(rent=2800, first=old_first, last=NOW),
+    ]
+    stats = compute_rent_stats(listings, QUARTIERE, now=NOW)
+    months = [point["month"] for point in stats[1].trend]
+    assert len(months) <= TREND_MONTHS
+    assert months == sorted(months)
+    assert months[0] >= "2025-08"  # within the 12-month window of NOW
+
+
+def test_trend_points_are_json_ready_dicts():
+    listings = [_obs(), _obs(rent=2400), _obs(rent=2800)]
+    stats = compute_rent_stats(listings, QUARTIERE, now=NOW)
+    point = stats[1].trend[0]
+    assert set(point.keys()) == {"month", "median_chf_m2", "n"}


### PR DESCRIPTION
Upgrades the ROADMAP's "Rent trends per Quartier — 🟡 partial" (Layer 1, trajectory) to a working pipeline step. Feeds Layer 6 financial modeling later.

## What
`--rents` on the neighborhoods pipeline computes, per quartier, from Strata's own listings corpus:
- `rent_median_chf_m2` + `rent_listing_count` — current level over active listings
- `rent_trend` — last-12-months monthly median CHF/m² (a listing counts in every month of its visibility span; months with n<3 omitted)

## Design
- **Pure math separated from IO** — `compute_rent_stats` is fully unit-tested with hand-computed medians at each rule boundary; DB read is a thin slice loader; the runner step degrades gracefully (logs + continues without rent properties) if the DB is unavailable
- **Point-in-polygon quartier assignment** via a shared `geometry.py` extracted from amenities (re-exported for back-compat); coordless or out-of-city listings are skipped with logged counts — no invented PLZ mapping
- **Documented simplification**: each listing contributes its final `rent_net` across its whole span; replaying `listing_history` price changes is a noted future upgrade
- Plausibility guards: rent ≤ 0 or area < 8 m² excluded

## Provenance
Implemented inline by the orchestrator after the assigned Opus agent lost its worktree to repeated infra stream stalls (5×, zero files); its one salvageable artifact — the extracted ray-casting helper — was reused verbatim. TDD throughout.

## Testing
+15 → **744 backend tests**, zero regressions; ruff clean. Code+tests only — no data files regenerated (local DB state unknown; run `--rents` after the prod DB restore).

## Follow-ups
- Quartier profile UI: rent level + sparkline from `rent_trend`
- listing_history replay for exact historical pricing