### PR TITLE
ci: scheduled static-data refresh (daily air quality, commit-back)

### DIFF
--- a/.github/workflows/data-refresh.yml
+++ b/.github/workflows/data-refresh.yml
@@ -1,0 +1,52 @@
+name: Static data refresh
+
+# Regenerates committed data files that do NOT need the deployed API/DB and
+# commits them back to main. Complements pipelines.yml (which triggers the
+# deployed API and is dark while the deployment is down).
+#
+# - Daily: air quality (UGZ hourly open data → air_quality.geojson)
+# Runs are idempotent: no commit is created when the data is unchanged.
+
+on:
+  schedule:
+    - cron: '15 4 * * *' # daily 04:15 UTC — after the UGZ nightly data lands
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+
+concurrency:
+  group: data-refresh
+  cancel-in-progress: false
+
+jobs:
+  air-quality:
+    name: Air quality GeoJSON
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Install API package
+        working-directory: apps/api
+        run: |
+          uv venv
+          uv pip install -e ".[dev]"
+
+      - name: Run air-quality pipeline
+        working-directory: apps/api
+        run: uv run python -m strata_api.pipeline.air
+
+      - name: Commit refreshed data (if changed)
+        run: |
+          git config user.name "strata-data-bot"
+          git config user.email "actions@github.com"
+          git add apps/web/public/data/air_quality.geojson
+          if git diff --cached --quiet; then
+            echo "Air-quality data unchanged — nothing to commit."
+          else
+            git commit -m "data: refresh air_quality.geojson (scheduled)"
+            git push
+          fi


### PR DESCRIPTION
Small infra chore (autonomous dev loop, iteration 11).

The existing `pipelines.yml` cron triggers the **deployed API** — dark while the deployment is down. This new workflow covers the other class of data: files that are committed to the repo and need no DB, starting with the air-quality layer (#4).

- Daily 04:15 UTC: runs `python -m strata_api.pipeline.air` (UGZ open data) and commits `air_quality.geojson` back **only when changed**
- `workflow_dispatch` for manual runs; `concurrency` guard; `contents: write` scoped permission
- Pattern is ready to extend with weekly green/amenities refreshes later

No app code touched; CI green = mergeable.