### PR TITLE
feat: venue typology v1 — clubs, culture, live-music categories (#6)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -27,8 +27,8 @@ Update this file when phases shift. Claude Code reads it every session via CLAUD
 | Photos stored | 565+ |
 | Quartiere with profiles | 34 |
 | Noise data points | 1,071,340 |
-| Backend tests | 746 |
-| Frontend tests | 386 |
+| Backend tests | 753 |
+| Frontend tests | 388 |
 
 ---
 
@@ -66,7 +66,7 @@ The layer that answers "where should I live?" Four dimensions.
 |-----------|--------|-------------|-------|
 | **Demographics** (age, origin, gender) | 🟢 Done | Statistik Stadt Zürich CSV | — |
 | **Population density** | 🟢 Done | Derived from demographics + Quartier area | — |
-| **Venue typology** (cafés, nightlife, culture) | ⚪ Planned | OSM Overpass API or Google Places | #TBD |
+| **Venue typology** (cafés, nightlife, culture) | 🟢 v1 done — clubs/culture/live-music categories in amenities pipeline + profile grid (data after next --amenities refetch) | #6 |
 | **Vibe / character profiles** | 🟢 Done — quartile-based explainable tags + summary | — |
 
 #### Practical Dimension

--- a/apps/api/src/strata_api/pipeline/neighborhoods/amenities.py
+++ b/apps/api/src/strata_api/pipeline/neighborhoods/amenities.py
@@ -1,7 +1,9 @@
 """OSM amenities for the walkability layer — Overpass fetch, categorize, count per Quartier.
 
 Data source: OpenStreetMap via the public Overpass API. Elements are matched to
-seven amenity categories relevant to "where should I live?" and assigned to
+amenity categories relevant to "where should I live?" — an everyday-convenience
+group (groceries, cafes, restaurants, bars, pharmacies, schools, fitness) and a
+cultural/nightlife venue group (clubs, culture, music_venues) — and assigned to
 statistical Quartiere by point-in-polygon against the WFS boundaries.
 """
 from __future__ import annotations
@@ -25,15 +27,27 @@ OVERPASS_URL = "https://overpass-api.de/api/interpreter"
 # Stadt Zürich bounding box (south, west, north, east)
 ZURICH_BBOX = (47.30, 8.43, 47.45, 8.65)
 
-# category -> (tag key, accepted values)
-AMENITY_CATEGORIES: dict[str, tuple[str, frozenset[str]]] = {
-    "groceries": ("shop", frozenset({"supermarket", "convenience", "greengrocer"})),
-    "cafes": ("amenity", frozenset({"cafe"})),
-    "restaurants": ("amenity", frozenset({"restaurant", "fast_food"})),
-    "bars": ("amenity", frozenset({"bar", "pub"})),
-    "pharmacies": ("amenity", frozenset({"pharmacy"})),
-    "schools": ("amenity", frozenset({"school", "kindergarten"})),
-    "fitness": ("leisure", frozenset({"fitness_centre", "sports_centre"})),
+# category -> one or more (tag key, accepted values) rules. Most categories are
+# driven by a single tag key, but some (e.g. "culture") span several keys — a
+# tag matches the category if ANY rule matches.
+AMENITY_CATEGORIES: dict[str, tuple[tuple[str, frozenset[str]], ...]] = {
+    "groceries": (("shop", frozenset({"supermarket", "convenience", "greengrocer"})),),
+    "cafes": (("amenity", frozenset({"cafe"})),),
+    "restaurants": (("amenity", frozenset({"restaurant", "fast_food"})),),
+    "bars": (("amenity", frozenset({"bar", "pub"})),),
+    "pharmacies": (("amenity", frozenset({"pharmacy"})),),
+    "schools": (("amenity", frozenset({"school", "kindergarten"})),),
+    "fitness": (("leisure", frozenset({"fitness_centre", "sports_centre"})),),
+    # Cultural / nightlife venue group (issue #6) — captures the cultural
+    # character of a neighborhood. NOTE: these categories only appear in the
+    # generated data after an `--amenities` refetch, because the cached
+    # amenities_raw.json only contains tags from previously-run queries.
+    "clubs": (("amenity", frozenset({"nightclub"})),),
+    "culture": (
+        ("amenity", frozenset({"theatre", "cinema", "arts_centre"})),
+        ("tourism", frozenset({"museum", "gallery"})),
+    ),
+    "music_venues": (("amenity", frozenset({"music_venue", "concert_hall"})),),
 }
 
 
@@ -48,9 +62,10 @@ class AmenityPoint(BaseModel, frozen=True):
 
 def categorize_tags(tags: dict) -> str | None:
     """Map an OSM tag dict to one of AMENITY_CATEGORIES, or None if irrelevant."""
-    for category, (key, values) in AMENITY_CATEGORIES.items():
-        if tags.get(key) in values:
-            return category
+    for category, rules in AMENITY_CATEGORIES.items():
+        for key, values in rules:
+            if tags.get(key) in values:
+                return category
     return None
 
 
@@ -59,8 +74,9 @@ def build_overpass_query(bbox: tuple[float, float, float, float] = ZURICH_BBOX) 
     bbox_str = ",".join(str(v) for v in bbox)
     # Several categories share a tag key (amenity) — union their values per key
     merged: dict[str, set[str]] = {}
-    for key, values in AMENITY_CATEGORIES.values():
-        merged.setdefault(key, set()).update(values)
+    for rules in AMENITY_CATEGORIES.values():
+        for key, values in rules:
+            merged.setdefault(key, set()).update(values)
 
     clauses = []
     for key, values in merged.items():

--- a/apps/api/tests/pipeline/neighborhoods/test_amenities.py
+++ b/apps/api/tests/pipeline/neighborhoods/test_amenities.py
@@ -57,6 +57,22 @@ OVERPASS_RESPONSE = {
         },
         # node without tags — skipped
         {"type": "node", "id": 6, "lat": 47.35, "lon": 8.50},
+        # nightclub node — cultural/nightlife venue group (issue #6)
+        {
+            "type": "node",
+            "id": 7,
+            "lat": 47.40,
+            "lon": 8.55,
+            "tags": {"amenity": "nightclub", "name": "Club X"},
+        },
+        # museum node — culture category via the tourism tag key
+        {
+            "type": "node",
+            "id": 8,
+            "lat": 47.41,
+            "lon": 8.56,
+            "tags": {"tourism": "museum", "name": "Kunsthaus"},
+        },
     ],
 }
 
@@ -80,9 +96,21 @@ class TestParseOverpassAmenities:
         pharmacy = next(p for p in points if p.category == "pharmacies")
         assert pharmacy.name is None
 
+    def test_parses_nightclub_node(self):
+        points = parse_overpass_amenities(OVERPASS_RESPONSE)
+        club = next(p for p in points if p.category == "clubs")
+        assert club.name == "Club X"
+        assert club.lat == pytest.approx(47.40)
+
+    def test_parses_tourism_museum_as_culture(self):
+        points = parse_overpass_amenities(OVERPASS_RESPONSE)
+        museum = next(p for p in points if p.category == "culture")
+        assert museum.name == "Kunsthaus"
+        assert museum.lon == pytest.approx(8.56)
+
     def test_irrelevant_and_invalid_elements_skipped(self):
         points = parse_overpass_amenities(OVERPASS_RESPONSE)
-        assert len(points) == 3  # cafe, supermarket, pharmacy
+        assert len(points) == 5  # cafe, supermarket, pharmacy, nightclub, museum
 
     def test_empty_response(self):
         assert parse_overpass_amenities({"elements": []}) == []
@@ -115,13 +143,31 @@ class TestCategorizeTags:
         assert categorize_tags({"leisure": "fitness_centre"}) == "fitness"
         assert categorize_tags({"leisure": "sports_centre"}) == "fitness"
 
+    def test_clubs(self):
+        assert categorize_tags({"amenity": "nightclub"}) == "clubs"
+
+    def test_culture_amenity_values(self):
+        assert categorize_tags({"amenity": "theatre"}) == "culture"
+        assert categorize_tags({"amenity": "cinema"}) == "culture"
+        assert categorize_tags({"amenity": "arts_centre"}) == "culture"
+
+    def test_culture_tourism_values(self):
+        assert categorize_tags({"tourism": "museum"}) == "culture"
+        assert categorize_tags({"tourism": "gallery"}) == "culture"
+
+    def test_music_venues(self):
+        assert categorize_tags({"amenity": "music_venue"}) == "music_venues"
+        assert categorize_tags({"amenity": "concert_hall"}) == "music_venues"
+
     def test_unknown_returns_none(self):
         assert categorize_tags({"amenity": "parking"}) is None
+        assert categorize_tags({"tourism": "hotel"}) is None
         assert categorize_tags({}) is None
 
     def test_all_categories_registered(self):
         assert set(AMENITY_CATEGORIES) == {
             "groceries", "cafes", "restaurants", "bars", "pharmacies", "schools", "fitness",
+            "clubs", "culture", "music_venues",
         }
 
 
@@ -219,9 +265,19 @@ class TestBuildOverpassQuery:
         from strata_api.pipeline.neighborhoods.amenities import build_overpass_query
 
         query = build_overpass_query()
-        for _key, values in AMENITY_CATEGORIES.values():
-            for value in values:
-                assert value in query, f"{value} missing from Overpass query"
+        for rules in AMENITY_CATEGORIES.values():
+            for _key, values in rules:
+                for value in values:
+                    assert value in query, f"{value} missing from Overpass query"
+
+    def test_query_includes_tourism_and_venue_tags(self):
+        from strata_api.pipeline.neighborhoods.amenities import build_overpass_query
+
+        query = build_overpass_query()
+        assert 'node["tourism"' in query
+        assert "nightclub" in query
+        assert "music_venue" in query
+        assert "museum" in query
 
     def test_query_has_node_and_way_clauses(self):
         from strata_api.pipeline.neighborhoods.amenities import build_overpass_query

--- a/apps/web/src/components/map/QuartierProfile.test.tsx
+++ b/apps/web/src/components/map/QuartierProfile.test.tsx
@@ -109,7 +109,10 @@ describe('QuartierProfile amenities', () => {
     pharmacies: 4,
     schools: 6,
     fitness: 5,
-    total: 90,
+    clubs: 3,
+    culture: 7,
+    music_venues: 2,
+    total: 102,
     per_km2: 18.4,
   };
 
@@ -119,6 +122,35 @@ describe('QuartierProfile amenities', () => {
     expect(screen.getByText('Groceries')).toBeTruthy();
     expect(screen.getByText('21')).toBeTruthy();
     expect(screen.getByText('Bars & pubs')).toBeTruthy();
+  });
+
+  it('renders the cultural/nightlife venue categories', () => {
+    render(<QuartierProfile profile={{ ...fullProfile, amenities }} />);
+    expect(screen.getByText('Clubs')).toBeTruthy();
+    expect(screen.getByText('Culture')).toBeTruthy();
+    expect(screen.getByText('Live music')).toBeTruthy();
+    expect(screen.getByText('7')).toBeTruthy();
+  });
+
+  it('tolerates data missing the new venue keys by rendering 0', () => {
+    // Simulates cached data generated before the venue categories existed
+    // (a refetch is required to populate them). Labels must still render.
+    const legacy = {
+      groceries: 8,
+      cafes: 21,
+      restaurants: 34,
+      bars: 12,
+      pharmacies: 4,
+      schools: 6,
+      fitness: 5,
+      total: 90,
+      per_km2: 18.4,
+    };
+    render(<QuartierProfile profile={{ ...fullProfile, amenities: legacy }} />);
+    expect(screen.getByText('Clubs')).toBeTruthy();
+    expect(screen.getByText('Live music')).toBeTruthy();
+    // three venue categories all fall back to 0
+    expect(screen.getAllByText('0').length).toBeGreaterThanOrEqual(3);
   });
 
   it('renders amenity density per km2', () => {

--- a/apps/web/src/components/map/QuartierProfile.tsx
+++ b/apps/web/src/components/map/QuartierProfile.tsx
@@ -67,7 +67,7 @@ function AmenitiesSection({ amenities }: { amenities: QuartierAmenities }) {
         {AMENITY_LABELS.map(({ key, label }) => (
           <div key={key} className="flex items-baseline justify-between py-[3px]">
             <dt className="text-2xs text-strata-cream/50">{label}</dt>
-            <dd className="strata-data text-xs-11 text-strata-cream">{amenities[key]}</dd>
+            <dd className="strata-data text-xs-11 text-strata-cream">{amenities[key] ?? 0}</dd>
           </div>
         ))}
       </dl>

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -71,6 +71,12 @@ export interface QuartierAmenities {
   pharmacies: number;
   schools: number;
   fitness: number;
+  // Cultural/nightlife venue group (issue #6). Optional because data generated
+  // before these categories existed lacks them until an `--amenities` refetch;
+  // the UI treats an absent key as 0.
+  clubs?: number;
+  culture?: number;
+  music_venues?: number;
   total: number;
   per_km2: number | null;
 }

--- a/apps/web/src/lib/quartier-display.ts
+++ b/apps/web/src/lib/quartier-display.ts
@@ -13,4 +13,7 @@ export const AMENITY_LABELS: { key: keyof QuartierAmenities; label: string }[] =
   { key: 'pharmacies', label: 'Pharmacies' },
   { key: 'schools', label: 'Schools' },
   { key: 'fitness', label: 'Fitness' },
+  { key: 'clubs', label: 'Clubs' },
+  { key: 'culture', label: 'Culture' },
+  { key: 'music_venues', label: 'Live music' },
 ];


### PR DESCRIPTION
Bounded v1 of #6 (Layer 1, social dimension) — built TDD by an Opus 4.8 agent, verified and shipped by the orchestrator (autonomous dev loop, iteration 12, final feature of the run).

## What
Three cultural/nightlife categories join the amenities pipeline and quartier profile grid:
| Category | OSM tags |
|---|---|
| Clubs | `amenity=nightclub` |
| Culture | `amenity=theatre/cinema/arts_centre`, `tourism=museum/gallery` |
| Live music | `amenity=music_venue/concert_hall` |

`AMENITY_CATEGORIES` was restructured so one category can span multiple tag keys; the Overpass query, classifier, per-quartier counts, `total`, and `per_km2` all flow from the constant — no duplicated logic.

## Data note (honest)
The cached `amenities_raw.json` predates these tags, so counts appear after the next `--amenities` refetch. Until then the profile grid shows the new labels with 0 (legacy-data tolerance is explicitly tested); freshly-run pipeline data always emits all keys.

## Testing
- Backend +7 → **753 tests**, ruff clean
- Frontend +2 → **388 tests**, lint 0 errors, tsc clean

## Follow-up (future v2, beyond this issue's v1)
Venue *character* profiles (typology mix → vibe evidence), Google Places cross-check.